### PR TITLE
Add ToString implementation to CecilType.

### DIFF
--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -47,6 +47,8 @@ namespace XamlX.TypeSystem
                 return CecilHelpers.Equals(Reference, o.Reference);
             }
 
+            public override string ToString() => Definition.ToString();
+
             public object Id => Reference.FullName;
             public string Name => Reference.Name;
             public string FullName => Reference.FullName;


### PR DESCRIPTION
Without this errors during build just print name of `CecilType` name and not correct definition type name.

![image](https://user-images.githubusercontent.com/2588062/88323618-cd968f80-cd22-11ea-99c2-cb00659ee7e0.png)
