### PR TITLE
Don't duplicate line info in exception message.

### DIFF
--- a/src/XamlX/Exceptions.cs
+++ b/src/XamlX/Exceptions.cs
@@ -10,8 +10,7 @@ namespace XamlX
     class XamlParseException : XmlException
     {
         public XamlParseException(string message, int line, int position) : base(
-            $"{message} (line {line} position {position})",
-            null, line, position)
+            message, null, line, position)
         {
         }
 


### PR DESCRIPTION
`XmlException` already includes the line/column number in the exception message, so we don't need to do it in `XamlException` too.