### PR TITLE
Upstream changes made for the experimental WinUI compiler.

### DIFF
--- a/src/XamlX.IL.Cecil/CecilCustomAttribute.cs
+++ b/src/XamlX.IL.Cecil/CecilCustomAttribute.cs
@@ -37,9 +37,26 @@ namespace XamlX.TypeSystem
 
             private Dictionary<string, object> _properties;
 
-            public Dictionary<string, object> Properties =>
-                _properties ?? (_properties =
-                    Data.Properties.ToDictionary(d => d.Name, d => ConvertValue(d.Argument.Value)));
+            public Dictionary<string, object> Properties
+            {
+                get
+                {
+                    if (_properties is null)
+                    {
+                        Dictionary<string, object> properties = new Dictionary<string, object>();
+                        foreach (var prop in Data.Properties)
+                        {
+                            properties.Add(prop.Name, ConvertValue(prop.Argument.Value));
+                        }
+                        foreach (var field in Data.Fields)
+                        {
+                            properties.Add(field.Name, ConvertValue(field.Argument.Value));
+                        }
+                        _properties = properties;
+                    }
+                    return _properties;
+                }
+            }
         }
     }
 }

--- a/src/XamlX.IL.Cecil/CecilTypeSystem.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeSystem.cs
@@ -62,7 +62,8 @@ namespace XamlX.TypeSystem
                     AssemblyResolver = this,
                     MetadataResolver = _resolver,
                     ThrowIfSymbolsAreNotMatching = false,
-                    SymbolReaderProvider = isTarget ? new DefaultSymbolReaderProvider(false) : null
+                    SymbolReaderProvider = isTarget ? new DefaultSymbolReaderProvider(false) : null,
+                    ApplyWindowsRuntimeProjections = false
                 });
 
                 var wrapped = RegisterAssembly(asm);

--- a/src/XamlX/IL/Emitters/ObjectInitializationNodeEmitter.cs
+++ b/src/XamlX/IL/Emitters/ObjectInitializationNodeEmitter.cs
@@ -70,11 +70,7 @@ namespace XamlX.IL.Emitters
     {
         public static void Verify(XamlContextBase ctx, IXamlAstNode node)
         {
-            var cache = ctx.GetItem<XamlNeedsParentStackCache>();
-            // There is no parent stack
-            if (cache == null)
-                return;
-            if (!cache.ContainsKey(node))
+            if (ctx.TryGetItem<XamlNeedsParentStackCache>(out var cache) && !cache.ContainsKey(node))
                 throw new XamlLoadException("Node needs parent stack, but one doesn't seem to be provided", node);
         }
         class ParentStackVisitor : IXamlAstVisitor

--- a/src/XamlX/IL/RuntimeContext.cs
+++ b/src/XamlX/IL/RuntimeContext.cs
@@ -378,7 +378,10 @@ namespace XamlX.IL
             Constructor = ctor;
             CreateCallbacks.Add(() => { parentBuilder.CreateType(); });
             
-            EmitPushPopParent(builder, typeSystem);
+            if (ParentListField != null)
+            {
+                EmitPushPopParent(builder, typeSystem);
+            }
             
             CreateAllTypes();
             ContextType = builder.CreateType();

--- a/src/XamlX/Transform/NamespaceInfoHelper.cs
+++ b/src/XamlX/Transform/NamespaceInfoHelper.cs
@@ -53,6 +53,19 @@ namespace XamlX.Transform
                 };
             }
 
+            const string usingPrefix = "using:";
+            if (xmlns.StartsWith(usingPrefix))
+            {
+                var ns = xmlns.Substring(usingPrefix.Length);
+                return new List<NamespaceResolveResult>
+                {
+                    new NamespaceResolveResult
+                    {
+                        ClrNamespace = ns
+                    }
+                };
+            }
+
             return null;
         }
     }

--- a/src/XamlX/Transform/NamespaceInfoHelper.cs
+++ b/src/XamlX/Transform/NamespaceInfoHelper.cs
@@ -29,14 +29,16 @@ namespace XamlX.Transform
                     Assembly = p.asm
                 }).ToList();
             }
+
+            var prefixStringComparison = StringComparison.Ordinal;
             
             const string clrNamespace = "clr-namespace:";
             const string assemblyNamePrefix = ";assembly=";
-            if (xmlns.StartsWith(clrNamespace))
+            if (xmlns.StartsWith(clrNamespace, prefixStringComparison))
             {
                 var ns = xmlns.Substring(clrNamespace.Length);
                 
-                var indexOfAssemblyPrefix = ns.IndexOf(assemblyNamePrefix, StringComparison.Ordinal);
+                var indexOfAssemblyPrefix = ns.IndexOf(assemblyNamePrefix, prefixStringComparison);
                 string asm = config.DefaultAssembly?.Name;
                 if (indexOfAssemblyPrefix != -1)
                 {
@@ -54,7 +56,7 @@ namespace XamlX.Transform
             }
 
             const string usingPrefix = "using:";
-            if (xmlns.StartsWith(usingPrefix))
+            if (xmlns.StartsWith(usingPrefix, prefixStringComparison))
             {
                 var ns = xmlns.Substring(usingPrefix.Length);
                 return new List<NamespaceResolveResult>

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -76,7 +76,11 @@ namespace XamlX.Transform
 
             foreach (var contentAttributeOnType in GetCustomAttribute(type, TypeMappings.ContentAttributes))
             {
-                if (contentAttributeOnType.Parameters[0] is string propertyName)
+                if (contentAttributeOnType.Properties.Count == 0)
+                {
+                    throw new XamlTypeSystemException($"The '{contentAttributeOnType.Type}' attribute must have a property name specified");
+                }
+                if (contentAttributeOnType.Properties["Name"] is string propertyName)
                 {
                     IXamlProperty contentProperty = type.GetAllProperties().FirstOrDefault(prop => prop.Name == propertyName);
                     if (contentProperty is null)

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -73,6 +73,23 @@ namespace XamlX.Transform
             // Check the base type first, we'll need to throw on duplicate Content property later
             if (type.BaseType != null)
                 found = FindContentProperty(type.BaseType);
+
+            foreach (var contentAttributeOnType in GetCustomAttribute(type, TypeMappings.ContentAttributes))
+            {
+                if (contentAttributeOnType.Parameters[0] is string propertyName)
+                {
+                    IXamlProperty contentProperty = type.GetAllProperties().FirstOrDefault(prop => prop.Name == propertyName);
+                    if (contentProperty is null)
+                    {
+                        throw new XamlTypeSystemException($"The property name '{propertyName}' specified in the content property of {type.GetFqn()} does not exist.");
+                    }
+
+                    if (found != null && !contentProperty.Equals(found))
+                        throw new XamlTypeSystemException(
+                            "Content (or substitute) attribute is declared on multiple properties of " + type.GetFqn());
+                    found = contentProperty;
+                }
+            }
             
             foreach (var p in type.Properties)
             {

--- a/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
@@ -47,7 +47,7 @@ namespace XamlX.Transform.Transformers
                                                                                     && p.Add != null);
                     if (clrEvent != null)
                         return new XamlAstClrProperty(prop,
-                            prop.Name, declaringType, null, clrEvent.Add);
+                            prop.Name, clrEvent.Add.DeclaringType, null, clrEvent.Add);
                 }
 
                 // Look for attached properties on declaring type

--- a/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
@@ -78,11 +78,20 @@ namespace XamlX.Transform.Transformers
                         foreach (var resolvedNs in resolvedNamespaces)
                         {
                             var rname = resolvedNs.ClrNamespace + "." + formedName;
-                            IXamlType subRes;
+                            IXamlType subRes = null;
                             if (resolvedNs.Assembly != null)
                                 subRes = resolvedNs.Assembly.FindType(rname);
-                            else
+                            else if (resolvedNs.AssemblyName != null)
                                 subRes = context.Configuration.TypeSystem.FindType(rname, resolvedNs.AssemblyName);
+                            else
+                            {
+                                foreach (var assembly in context.Configuration.TypeSystem.Assemblies)
+                                {
+                                    subRes = assembly.FindType(rname);
+                                    if (subRes != null)
+                                        break;
+                                }
+                            }
                             if (subRes != null)
                                 return subRes;
                         }

--- a/src/XamlX/Transform/XamlLanguageTypeMappings.cs
+++ b/src/XamlX/Transform/XamlLanguageTypeMappings.cs
@@ -18,6 +18,19 @@ namespace XamlX.Transform
                 TypeConverterAttributes.Add(tconv);
         }
 
+        public XamlLanguageTypeMappings(IXamlTypeSystem typeSystem, bool useDefault)
+        {
+            if (useDefault)
+            {
+                ServiceProvider = typeSystem.GetType("System.IServiceProvider");
+                TypeDescriptorContext = typeSystem.GetType("System.ComponentModel.ITypeDescriptorContext");
+                SupportInitialize = typeSystem.GetType("System.ComponentModel.ISupportInitialize");
+                var tconv = typeSystem.GetType("System.ComponentModel.TypeConverterAttribute");
+                if (tconv != null)
+                    TypeConverterAttributes.Add(tconv);
+            }
+        }
+
         public List<IXamlType> XmlnsAttributes { get; set; } = new List<IXamlType>();
         public List<IXamlType> UsableDuringInitializationAttributes { get; set; } = new List<IXamlType>();
         public List<IXamlType> ContentAttributes { get; set; } = new List<IXamlType>();

--- a/tests/XamlParserTests/ServiceProviderTests.cs
+++ b/tests/XamlParserTests/ServiceProviderTests.cs
@@ -256,6 +256,50 @@ namespace XamlParserTests
         }
         
         [Fact]
+        public void Namespace_Info_Should_Be_Preserved_With_Using_Syntax()
+        {
+            CompileAndRun(@"
+<ServiceProviderTestsClass 
+    xmlns='using:XamlParserTests'
+    xmlns:clr1='using:System.Collections.Generic'
+    xmlns:clr2='using:Dummy'
+    Property='{Callback}'/>", sp =>
+            {
+                var nsList = sp.GetService<IXamlXmlNamespaceInfoProviderV1>().XmlNamespaces;
+                // Direct calls without struct diff because of EntryPointNotFoundException issue before
+                Assert.True(nsList.TryGetValue("clr1", out var xlst));
+                Assert.Equal("System.Collections.Generic", xlst[0].ClrNamespace);
+                Helpers.StructDiff(nsList,
+                    new Dictionary<string, IReadOnlyList<XamlXmlNamespaceInfoV1>>
+                    {
+                        [""] = new List<XamlXmlNamespaceInfoV1>
+                        {
+                            new XamlXmlNamespaceInfoV1
+                            {
+                                ClrNamespace = "XamlParserTests"
+                            }
+                        },
+                        ["clr1"] = new List<XamlXmlNamespaceInfoV1>
+                        {
+                            new XamlXmlNamespaceInfoV1
+                            {
+                                ClrNamespace = "System.Collections.Generic"
+                            }
+                        },
+                        ["clr2"] = new List<XamlXmlNamespaceInfoV1>
+                        {
+                            new XamlXmlNamespaceInfoV1
+                            {
+                                ClrNamespace = "Dummy"
+                            }
+                        }
+                    });
+                
+                return "Value";
+            }, null);
+        }
+        
+        [Fact]
         public void Uri_Context_Is_Usable()
         {
             bool ok = false;


### PR DESCRIPTION
This PR upstreams the changes made so far to support the experimental WinUI compiler (located at https://github.com/stevenbrix/xamlx-winui):

- Disable Mono.Cecil's support for WinRT projections in WinMDs.
- Enable reading `Content` attributes on types that point to a property name instead of being on a property directly.
- Allow disabling the default language type mappings.
- Enable building a compiler that does not use the parent stack provider at all.
- Support reading field initializers off of custom attributes with the Mono.Cecil type system.
- Support the `using:Namespace` syntax for xmlns declarations.
- Resolve events with the most specific declaring type possible instead of possibly returning subclasses.