### PR TITLE
Report errors even with strict mode

### DIFF
--- a/src/XamlX/Transform/AstTransformationContext.cs
+++ b/src/XamlX/Transform/AstTransformationContext.cs
@@ -14,12 +14,26 @@ namespace XamlX.Transform
         public Dictionary<string, string> NamespaceAliases { get; set; } = new Dictionary<string, string>();      
         public TransformerConfiguration Configuration { get; }
         public IXamlAstValueNode RootObject { get; set; }
-        public bool StrictMode { get; }
 
+        [Obsolete("Use error method instead, to report info about errors in AST")]
+        public bool StrictMode => _strictMode;
+
+        private bool _strictMode;
+        public List<Exception> Errors { get; } = new List<Exception>();
+
+        public void Error(Exception e)
+        {
+            if (_strictMode)
+                throw e;
+            else
+                Errors.Add(e);
+        }
         public IXamlAstNode Error(IXamlAstNode node, Exception e)
         {
-            if (StrictMode)
+            if (_strictMode)
                 throw e;
+            else
+                Errors.Add(e);
             return node;
         }
 
@@ -34,7 +48,7 @@ namespace XamlX.Transform
         {
             Configuration = configuration;
             NamespaceAliases = namespaceAliases;
-            StrictMode = strictMode;
+            _strictMode = strictMode;
         }
 
         class Visitor : IXamlAstVisitor

--- a/src/XamlX/Transform/AstTransformationContext.cs
+++ b/src/XamlX/Transform/AstTransformationContext.cs
@@ -23,17 +23,20 @@ namespace XamlX.Transform
 
         public void Error(Exception e)
         {
+            Errors.Add(e);
             if (_strictMode)
+            {
                 throw e;
-            else
-                Errors.Add(e);
+            }
         }
+
         public IXamlAstNode Error(IXamlAstNode node, Exception e)
         {
+            Errors.Add(e);
             if (_strictMode)
+            {
                 throw e;
-            else
-                Errors.Add(e);
+            }
             return node;
         }
 

--- a/src/XamlX/Transform/Transformers/KnownDirectivesTransformer.cs
+++ b/src/XamlX/Transform/Transformers/KnownDirectivesTransformer.cs
@@ -21,9 +21,9 @@ namespace XamlX.Transform.Transformers
                         {
                             if(ch is IXamlAstValueNode vn)
                                 vnodes.Add(vn);
-                            if (context.StrictMode)
-                                throw new XamlParseException(
-                                    "Only value nodes are allowed as directive children elements", ch);
+                            context.Error(ni, new XamlParseException(
+                                    "Only value nodes are allowed as directive children elements", ch));
+                                
                             
                         }
 

--- a/src/XamlX/Transform/Transformers/KnownDirectivesTransformer.cs
+++ b/src/XamlX/Transform/Transformers/KnownDirectivesTransformer.cs
@@ -21,10 +21,8 @@ namespace XamlX.Transform.Transformers
                         {
                             if(ch is IXamlAstValueNode vn)
                                 vnodes.Add(vn);
-                            context.Error(ni, new XamlParseException(
-                                    "Only value nodes are allowed as directive children elements", ch));
-                                
-                            
+                            context.ParseError("Only value nodes are allowed as directive children elements", ch);
+                            return ni;
                         }
 
                         return new XamlAstXmlDirective(ni, type.XmlNamespace, type.Name, vnodes);

--- a/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
@@ -16,19 +16,17 @@ namespace XamlX.Transform.Transformers
             {
                 if (!(prop.DeclaringType is XamlAstClrTypeReference declaringRef))
                 {
-                    if (context.StrictMode)
-                        throw new XamlParseException(
-                            $"Unable to resolve property {prop.Name} on {prop.DeclaringType}", node);
-                    else
-                        return node;
+                    context.Error(node,
+                        new XamlParseException(
+                            $"Unable to resolve property {prop.Name} on {prop.DeclaringType}", node));
+                    return node;
                 }
 
                 if (!(prop.TargetType is XamlAstClrTypeReference targetRef))
                 {
-                    if (context.StrictMode)
-                        throw new XamlParseException($"Unable to resolve property on {prop.DeclaringType}", node);
-                    else
-                        return node;
+                    context.Error(node, 
+                        new XamlParseException($"Unable to resolve property on {prop.DeclaringType}", node));
+                    return node;
                 }
 
                 var targetType = targetRef.Type;
@@ -80,10 +78,10 @@ namespace XamlX.Transform.Transformers
                 if (adder != null)
                     return new XamlAstClrProperty(prop, prop.Name, declaringType, null, adder);
 
-                if (context.StrictMode)
-                    throw new XamlParseException(
+                context.Error(node,
+                    new XamlParseException(
                         $"Unable to resolve suitable regular or attached property {prop.Name} on type {declaringType.GetFqn()}",
-                        node);
+                        node));
                 return null;
             }
 

--- a/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
@@ -16,16 +16,13 @@ namespace XamlX.Transform.Transformers
             {
                 if (!(prop.DeclaringType is XamlAstClrTypeReference declaringRef))
                 {
-                    context.Error(node,
-                        new XamlParseException(
-                            $"Unable to resolve property {prop.Name} on {prop.DeclaringType}", node));
+                    context.ParseError($"Unable to resolve property {prop.Name} on {prop.DeclaringType}", node);
                     return node;
                 }
 
                 if (!(prop.TargetType is XamlAstClrTypeReference targetRef))
                 {
-                    context.Error(node, 
-                        new XamlParseException($"Unable to resolve property on {prop.DeclaringType}", node));
+                    context.ParseError($"Unable to resolve property on {prop.DeclaringType}", node);
                     return node;
                 }
 
@@ -78,10 +75,7 @@ namespace XamlX.Transform.Transformers
                 if (adder != null)
                     return new XamlAstClrProperty(prop, prop.Name, declaringType, null, adder);
 
-                context.Error(node,
-                    new XamlParseException(
-                        $"Unable to resolve suitable regular or attached property {prop.Name} on type {declaringType.GetFqn()}",
-                        node));
+                context.ParseError($"Unable to resolve suitable regular or attached property {prop.Name} on type {declaringType.GetFqn()}",node);
                 return null;
             }
 

--- a/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
@@ -18,8 +18,7 @@ namespace XamlX.Transform.Transformers
         
         public static XamlAstClrTypeReference ResolveType(AstTransformationContext context,
             string xmlns, string name, bool isMarkupExtension, List<XamlAstXmlTypeReference> typeArguments,
-            IXamlLineInfo lineInfo,
-            bool strict)
+            IXamlLineInfo lineInfo)
         {
             if (typeArguments == null || typeArguments.Count == 0)
             {
@@ -32,24 +31,23 @@ namespace XamlX.Transform.Transformers
                     return new XamlAstClrTypeReference(lineInfo, type, isMarkupExtension);
                 }
 
-                var res = ResolveTypeCore(context, xmlns, name, isMarkupExtension, typeArguments, lineInfo, strict);
+                var res = ResolveTypeCore(context, xmlns, name, isMarkupExtension, typeArguments, lineInfo);
                 cache.CacheDictionary[cacheKey] = res?.Type;
                 return res;
 
             }
             else
-                return ResolveTypeCore(context, xmlns, name, isMarkupExtension, typeArguments, lineInfo, strict);
+                return ResolveTypeCore(context, xmlns, name, isMarkupExtension, typeArguments, lineInfo);
         }
 
         static XamlAstClrTypeReference ResolveTypeCore(AstTransformationContext context,
-            string xmlns, string name, bool isMarkupExtension, List<XamlAstXmlTypeReference> typeArguments, IXamlLineInfo lineInfo,
-            bool strict)
+            string xmlns, string name, bool isMarkupExtension, List<XamlAstXmlTypeReference> typeArguments, IXamlLineInfo lineInfo)
         {
             if (typeArguments == null)
                 typeArguments = new List<XamlAstXmlTypeReference>();
             var targs = typeArguments
                 .Select(ta =>
-                    ResolveType(context, ta.XmlNamespace, ta.Name, false, ta.GenericArguments, lineInfo, strict)
+                    ResolveType(context, ta.XmlNamespace, ta.Name, false, ta.GenericArguments, lineInfo)
                         ?.Type)
                 .ToList();
             
@@ -96,9 +94,9 @@ namespace XamlX.Transform.Transformers
             if (found != null)
                 return new XamlAstClrTypeReference(lineInfo, found,
                     isMarkupExtension || found.Name.EndsWith("Extension")); 
-            if (strict)
-                throw new XamlParseException(
-                    $"Unable to resolve type {name} from namespace {xmlns}", lineInfo);
+            context.Error(null,
+                new XamlParseException(
+                    $"Unable to resolve type {name} from namespace {xmlns}", lineInfo));
             return null;
         }
 
@@ -116,14 +114,14 @@ namespace XamlX.Transform.Transformers
                 return null;
             }
 
-            return ResolveType(context, xmlns, name, isMarkupExtension, new List<XamlAstXmlTypeReference>(), lineInfo, strict);
+            return ResolveType(context, xmlns, name, isMarkupExtension, new List<XamlAstXmlTypeReference>(), lineInfo);
         }
 
         public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
         {
             if (node is XamlAstXmlTypeReference xmlref)
             {
-                var resolved = ResolveType(context, xmlref, context.StrictMode);
+                var resolved = ResolveType(context, xmlref);
                 if (resolved == null)
                     return node;
                 return resolved;
@@ -133,11 +131,29 @@ namespace XamlX.Transform.Transformers
         }
 
         public static XamlAstClrTypeReference ResolveType(AstTransformationContext context,
-            XamlAstXmlTypeReference xmlref, bool strict)
+            XamlAstXmlTypeReference xmlref)
         {
             return ResolveType(context, xmlref.XmlNamespace, xmlref.Name, xmlref.IsMarkupExtension,
-                xmlref.GenericArguments, xmlref, strict);
+                xmlref.GenericArguments, xmlref);
 
         }
+
+
+        #region Obsolete compatibiltiy members
+        [Obsolete("Use overload without strict parameter, it is passed via context already")]
+        public static XamlAstClrTypeReference ResolveType(AstTransformationContext context,
+            XamlAstXmlTypeReference xmlref, bool strict)
+        {
+            return ResolveType(context, xmlref);
+        }
+
+        [Obsolete("Use overload without strict parameter, it is passed via context already")]
+        public static XamlAstClrTypeReference ResolveType(AstTransformationContext context,
+            string xmlns, string name, bool isMarkupExtension, List<XamlAstXmlTypeReference> typeArguments,
+            IXamlLineInfo lineInfo, bool strict)
+        {
+            return ResolveType(context, xmlns, name, isMarkupExtension, typeArguments, lineInfo);
+        }
+        #endregion
     }
 }

--- a/src/XamlX/Transform/Transformers/XArgumentsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XArgumentsTransformer.cs
@@ -15,9 +15,10 @@ namespace XamlX.Transform.Transformers
                 var argDirectives = ni.Children.OfType<XamlAstObjectNode>()
                     .Where(d => d.Type is XamlAstXmlTypeReference xref
                                 && xref.XmlNamespace == XamlNamespaces.Xaml2006 && xref.Name == "Arguments").ToList();
-                if (argDirectives.Count > 1 && context.StrictMode)
-                    throw new XamlParseException("x:Arguments directive is specified more than once",
-                        argDirectives[1]);
+                if (argDirectives.Count > 1)
+                    context.Error(
+                    new XamlParseException("x:Arguments directive is specified more than once",
+                        argDirectives[1]));
                 if (argDirectives.Count == 0)
                     return node;
                 ni.Arguments = argDirectives[0].Children.OfType<IXamlAstValueNode>().ToList();

--- a/src/XamlX/Transform/Transformers/XArgumentsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XArgumentsTransformer.cs
@@ -16,9 +16,11 @@ namespace XamlX.Transform.Transformers
                     .Where(d => d.Type is XamlAstXmlTypeReference xref
                                 && xref.XmlNamespace == XamlNamespaces.Xaml2006 && xref.Name == "Arguments").ToList();
                 if (argDirectives.Count > 1)
-                    context.Error(
-                    new XamlParseException("x:Arguments directive is specified more than once",
-                        argDirectives[1]));
+                {
+                    context.ParseError("x:Arguments directive is specified more than once", argDirectives[1]);
+                    return node;
+                }
+                    
                 if (argDirectives.Count == 0)
                     return node;
                 ni.Arguments = argDirectives[0].Children.OfType<IXamlAstValueNode>().ToList();


### PR DESCRIPTION
## What does the pull request do?
This PR allow compiler to report errors in non-strict mode
Also removes some unnecessary parameters (old members are obsoleted).

## What is the current behavior?
Currently there are ifs in code, which check if there is strict mode and throw exceptions, or do nothing. In such situation it is impossible to gather diagnostics, because all errors are ignored.


## What is the updated/expected behavior with this PR?
StrictMode is unchanged. Non strict mode is unchanged, but not thrown exceptions are stored to be analyzed for later.

## How was the solution implemented (if it's not obvious)?
`AstTransformationContext` is augmented with list of error and new `Error` method, which throws or adds error to list

## Breaking changes
None, made `StrictMode` obsolete, so transformers use `Error` method, instead of handling strict mode manually. Also obsoleted members with strict mode passed as parameter (it was passed anyway in context, no reason to pass it twice).