### PR TITLE
Added support for x:Array extension, including inline syntax

### DIFF
--- a/src/XamlX/Compiler/XamlCompiler.cs
+++ b/src/XamlX/Compiler/XamlCompiler.cs
@@ -43,7 +43,8 @@ namespace XamlX.Compiler
                     new ResolveContentPropertyTransformer(),
                     new ResolvePropertyValueAddersTransformer(),
                     new ConvertPropertyValuesToAssignmentsTransformer(),
-                    new ConstructableObjectTransformer()
+                    new ConstructableObjectTransformer(),
+                    new ArrayElementTransformer()
                 };
                 SimplificationTransformers = new List<IXamlAstTransformer>
                 {

--- a/src/XamlX/IL/Emitters/ArrayEmitter.cs
+++ b/src/XamlX/IL/Emitters/ArrayEmitter.cs
@@ -1,0 +1,54 @@
+﻿using XamlX.Ast;
+using XamlX.Emit;
+using XamlX.TypeSystem;
+
+namespace XamlX.IL.Emitters
+{
+#if !XAMLX_INTERNAL
+    public
+#endif
+    class ArrayEmitter : IXamlAstNodeEmitter<IXamlILEmitter, XamlILNodeEmitResult>
+    {
+        public XamlILNodeEmitResult Emit(IXamlAstNode node, XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            if (!(node is XamlArrayExtensionNode arrayNode))
+            {
+                return null;
+            }
+
+            var type = arrayNode.Type.GetClrType();
+            var elementType = type.ArrayElementType;
+
+            codeGen
+                .Ldc_I4(arrayNode.Elements.Count)
+                .Newarr(elementType);
+
+            for (int i = 0; i < arrayNode.Elements.Count; i++)
+            {
+                var element = arrayNode.Elements[i];
+
+                if (!elementType.IsAssignableFrom(element.Type.GetClrType()))
+                {
+                    throw new XamlLoadException("x:Array element is not assignable to the array element type!", element);
+                }
+
+                codeGen
+                    .Dup()
+                    .Ldc_I4(i);
+
+                context.Emit(element, codeGen, elementType);
+
+                if (elementType.IsValueType)
+                {
+                    codeGen.Stelem(elementType);
+                }
+                else
+                {
+                    codeGen.Stelem_ref();
+                }
+            }
+
+            return XamlILNodeEmitResult.Type(0, type);
+        }
+    }
+}

--- a/src/XamlX/IL/XamlILEmitterExtensions.cs
+++ b/src/XamlX/IL/XamlILEmitterExtensions.cs
@@ -160,6 +160,9 @@ namespace XamlX.IL
 
         public static IXamlILEmitter Ldelem_ref(this IXamlILEmitter emitter) => emitter.Emit(OpCodes.Ldelem_Ref);
         public static IXamlILEmitter Stelem_ref(this IXamlILEmitter emitter) => emitter.Emit(OpCodes.Stelem_Ref);
+
+        public static IXamlILEmitter Stelem(this IXamlILEmitter emitter, IXamlType type) => emitter.Emit(OpCodes.Stelem, type);
+
         public static IXamlILEmitter Ldlen(this IXamlILEmitter emitter) => emitter.Emit(OpCodes.Ldlen);
 
         public static IXamlILEmitter Add(this IXamlILEmitter emitter) => emitter.Emit(OpCodes.Add);

--- a/src/XamlX/IL/XamlIlCompiler.cs
+++ b/src/XamlX/IL/XamlIlCompiler.cs
@@ -39,7 +39,8 @@ namespace XamlX.IL
                     new ManipulationGroupEmitter(),
                     new ValueWithManipulationsEmitter(),
                     new MarkupExtensionEmitter(),
-                    new ObjectInitializationNodeEmitter()
+                    new ObjectInitializationNodeEmitter(),
+                    new ArrayEmitter()
                 });
             }
         }

--- a/src/XamlX/Transform/Transformers/ArrayElementTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ArrayElementTransformer.cs
@@ -1,0 +1,34 @@
+﻿using XamlX.Ast;
+using XamlX.TypeSystem;
+
+namespace XamlX.Transform.Transformers
+{
+#if !XAMLX_INTERNAL
+    public
+#endif
+    class ArrayElementTransformer : IXamlAstTransformer
+    {
+        public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
+        {
+            if (node is XamlArrayExtensionNode array)
+            {
+                var elementType = array.Type.GetClrType().ArrayElementType;
+
+                for (int i = 0; i < array.Elements.Count; i++)
+                {
+                    var element = array.Elements[i];
+
+                    if (!XamlTransformHelpers.TryGetCorrectlyTypedValue(context, element, elementType, out var converted))
+                    {
+                        throw new XamlLoadException(
+                            $"Unable to convert value {element} to x:Array element type {elementType.GetFqn()}", element);
+                    }
+
+                    array.Elements[i] = converted;
+                }
+            }
+
+            return node;
+        }
+    }
+}

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 using XamlX.Ast;
 
 namespace XamlX.Transform.Transformers
@@ -86,6 +89,56 @@ namespace XamlX.Transform.Transformers
                     return new XamlStaticExtensionNode(ni,
                         new XamlAstXmlTypeReference(ni, resolvedNs, tmpair[0], xml.GenericArguments),
                         tmpair[1]);
+                }
+
+                if (xml.Name == "Array")
+                {
+                    var elements = new List<IXamlAstValueNode>(ni.Arguments);
+
+                    IXamlAstValueNode type = null;
+
+                    foreach (var child in ni.Children)
+                    {
+                        if (child is XamlAstXamlPropertyValueNode propertyNode)
+                        {
+                            if (propertyNode.Property is XamlAstNamePropertyReference reference)
+                            {
+                                if (reference.Name.Equals("Type", StringComparison.Ordinal))
+                                {
+                                    if (type is object)
+                                    {
+                                        throw new XamlParseException("Duplicate Type property on x:Array!", ni);
+                                    }
+
+                                    if (propertyNode.Values.Count != 1)
+                                    {
+                                        throw new XamlParseException("The Type property on x:Array should have a single value!", ni);
+                                    }
+
+                                    type = propertyNode.Values[0];
+                                }
+                                else
+                                {
+                                    throw new XamlParseException($"Unknown property '{reference.Name}' in x:Array!", ni);
+                                }
+                            }
+                        }
+                        else if (child is IXamlAstValueNode valueNode)
+                        {
+                            elements.Add(valueNode);
+                        }
+                        else
+                        {
+                            context.ParseError("Invalid child node on x:Array!", child);
+                        }
+                    }
+
+                    if (type is null)
+                    {
+                        throw new XamlParseException("Required Type property on x:Array not found!", ni);
+                    }
+
+                    return new XamlArrayExtensionNode(ni, type, elements);
                 }
             }
 

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -89,5 +89,44 @@ namespace XamlParserTests
         {
             Static_Extension_Resolves_Values(IntrinsicsTestsEnum.Foo, "IntrinsicsTestsEnum.Foo");
         }
+
+        [Fact]
+        public void Array_Extension()
+        {
+            var res = (IntrinsicsTestsClass)CompileAndRun(@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <IntrinsicsTestsClass.ObjectProperty>
+        <x:Array Type='{x:Type x:Object}'>
+            <x:Object>A</x:Object>
+            <x:String>B</x:String>
+            <x:Int32>42</x:Int32>
+        </x:Array>
+    </IntrinsicsTestsClass.ObjectProperty>
+</IntrinsicsTestsClass>");
+
+            var array = (object[])res.ObjectProperty;
+
+            Assert.Equal("A", array[0]);
+            Assert.Equal("B", array[1]);
+            Assert.Equal(42, array[2]);
+        }
+
+        [Fact]
+        public void Array_Extension_Inline()
+        {
+            var res = (IntrinsicsTestsClass)CompileAndRun(@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    ObjectProperty='{x:Array 3, 5, 0, Type={x:Type x:Int32}}' />");
+
+            var array = (int[])res.ObjectProperty;
+
+            Assert.Equal(3, array[0]);
+            Assert.Equal(5, array[1]);
+            Assert.Equal(0, array[2]);
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Added support for `x:Array` extension, including inline syntax.

## Use cases

`x:Array` as in WPF isn't really useful I believe, as it can be easily replaced by list property setters. My main interest is the inline syntax (which doesn't exist in WPF), example:

```xaml
{x:Array 0, 1, 2, Type={x:Type x:Int32}}
```

### Passing constant data

```xaml
Data="{x:Array 5, 7, 1, 2, Type={x:Type x:Int32}}"
```

### Markup extensions (including multibindings)

For example, if `MultiBinding` (in Avalonia) was a markup extension it could be possibly used like this:

```xaml
Text="{MultiBinding {x:Array {Binding FirstName} {Binding LastName}, Type={x:Type IBinding}}, StringFormat='Hello, {0} {1}!'}"
```

I also investigated the possibility of handling `params` parameters, but that would be much more work, and this syntax is already considerably more readable in my opinion.