### PR TITLE
Resolve generic arguments when looking up fields.

### DIFF
--- a/src/XamlX.IL.Cecil/GenericTypeResolver.cs
+++ b/src/XamlX.IL.Cecil/GenericTypeResolver.cs
@@ -6,7 +6,7 @@ namespace XamlX.TypeSystem
 {
     internal class GenericTypeResolver
     {
-        private Dictionary<GenericParameter, TypeReference> lookup = new Dictionary<GenericParameter, TypeReference>();
+        private readonly Dictionary<GenericParameter, TypeReference> lookup = new Dictionary<GenericParameter, TypeReference>();
 
         public void Scan(TypeReference r)
         {

--- a/src/XamlX.IL.Cecil/GenericTypeResolver.cs
+++ b/src/XamlX.IL.Cecil/GenericTypeResolver.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Cecil.Rocks;
+
+namespace XamlX.TypeSystem
+{
+    internal class GenericTypeResolver
+    {
+        private Dictionary<GenericParameter, TypeReference> lookup = new Dictionary<GenericParameter, TypeReference>();
+
+        public void Scan(TypeReference r)
+        {
+            var typeRef = r;
+            var typeDef = typeRef.Resolve();
+
+            while (typeRef != null)
+            {
+                for (var i = 0; i < typeDef.GenericParameters.Count; ++i)
+                {
+                    if (typeDef.GenericParameters[i] is GenericParameter parameter &&
+                        typeRef is GenericInstanceType genericTypeRef &&
+                        genericTypeRef.GenericArguments.Count > i &&
+                        genericTypeRef.GenericArguments[i] is TypeReference arg &&
+                        !(arg is GenericParameter) &&
+                        !lookup.ContainsKey(parameter))
+                    {
+                        lookup.Add(parameter, arg);
+                    }
+                }
+
+                typeRef = typeDef.BaseType;
+                typeDef = typeRef?.Resolve();
+            }
+        }
+
+        public TypeReference Resolve(TypeReference r)
+        {
+            if (r is GenericInstanceType gi)
+            {
+                var args = new TypeReference[gi.GenericArguments.Count];
+
+                for (var i = 0; i < gi.GenericArguments.Count; ++i)
+                {
+                    var sourceArg = gi.GenericArguments[i];
+
+                    if (sourceArg is GenericParameter p)
+                    {
+                        if (lookup.TryGetValue(p, out var resolved))
+                        {
+                            args[i] = resolved;
+                        }
+                        else
+                        {
+                            throw new XamlTypeSystemException($"Could not resolve generic parameter '{p.Name}'.");
+                        }
+                    }
+                    else
+                    {
+                        args[i] = Resolve(sourceArg);
+                    }
+                }
+
+                return gi.ElementType.MakeGenericInstanceType(args);
+            }
+            else
+            {
+                return r;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When lookup up a field to import, make sure all generic arguments are resolved by looking at the declaring type and field type and then matching bounded generic arguments to parameters.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/3395