### PR TITLE
Evaluate the existence of a TypeConverter before finding for the Parser method.

### DIFF
--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -228,25 +228,6 @@ namespace XamlX.Transform
                                                      && m.Parameters.Count > 0
                                                      && m.Parameters[0].Equals(cfg.WellKnownTypes.String)).ToList();
 
-            // Types with parse method
-            var parser = candidates.FirstOrDefault(m =>
-                             m.Parameters.Count == 2 &&
-                             (
-                                 m.Parameters[1].Equals(cfg.WellKnownTypes.CultureInfo)
-                                 || m.Parameters[1].Equals(cfg.WellKnownTypes.IFormatProvider)
-                             )
-                         )
-                         ?? candidates.FirstOrDefault(m => m.Parameters.Count == 1);
-            if (parser != null)
-            {
-                var args = new List<IXamlAstValueNode> {node};
-                if (parser.Parameters.Count == 2)
-                    args.Add(CreateInvariantCulture());
-
-                rv = new XamlStaticOrTargetedReturnMethodCallNode(node, parser, args);
-                return true;
-            }
-
             if (cfg.TypeMappings.TypeDescriptorContext != null)
             {
                 IXamlType converterType = null;
@@ -276,6 +257,25 @@ namespace XamlX.Transform
                                 }), new XamlAstClrTypeReference(node, type, false)));
                     return true;
                 }
+            }
+
+            // Types with parse method
+            var parser = candidates.FirstOrDefault(m =>
+                             m.Parameters.Count == 2 &&
+                             (
+                                 m.Parameters[1].Equals(cfg.WellKnownTypes.CultureInfo)
+                                 || m.Parameters[1].Equals(cfg.WellKnownTypes.IFormatProvider)
+                             )
+                         )
+                         ?? candidates.FirstOrDefault(m => m.Parameters.Count == 1);
+            if (parser != null)
+            {
+                var args = new List<IXamlAstValueNode> { node };
+                if (parser.Parameters.Count == 2)
+                    args.Add(CreateInvariantCulture());
+
+                rv = new XamlStaticOrTargetedReturnMethodCallNode(node, parser, args);
+                return true;
             }
 
             return false;


### PR DESCRIPTION
This PR refers to this issue https://github.com/AvaloniaUI/Avalonia/issues/5039. When the compilation of xaml is enabled and you using a font ebbedded with the relative uri, it is thrown the ArgumentException because BaseUri is null. BaseUri is null because the XamlCompiler uses Parse instead of the TypeConverter.