### PR TITLE
Allow for emitting string constants.

### DIFF
--- a/src/XamlX/Ast/Intrinsics.cs
+++ b/src/XamlX/Ast/Intrinsics.cs
@@ -145,11 +145,10 @@ namespace XamlX.Ast
 
         public XamlConstantNode(IXamlLineInfo lineInfo, IXamlType type, object constant) : base(lineInfo)
         {
-            if (!constant.GetType().IsPrimitive)
+            if (!constant.GetType().IsPrimitive && constant.GetType() != typeof(string))
                 throw new ArgumentException($"Don't know how to emit {constant.GetType()} constant");
             Constant = constant;
             Type = new XamlAstClrTypeReference(lineInfo, type, false);
-
         }
 
         public IXamlAstTypeReference Type { get; }


### PR DESCRIPTION
I guess it was overlooked since actual `Emit` code supports strings.