### PR TITLE
Fix assemblies enumeration

### DIFF
--- a/src/XamlX.IL.Cecil/CecilTypeSystem.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeSystem.cs
@@ -77,7 +77,7 @@ namespace XamlX.TypeSystem
 
         public IXamlAssembly TargetAssembly { get; private set; }
         public AssemblyDefinition TargetAssemblyDefinition { get; private set; }
-        public IReadOnlyList<IXamlAssembly> Assemblies => _asms.AsReadOnly();
+        public IEnumerable<IXamlAssembly> Assemblies => _asms.AsReadOnly();
         public IXamlAssembly FindAssembly(string name) => _asms.FirstOrDefault(a => a.Assembly.Name.Name == name);
 
         public IXamlType FindType(string name)

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -15,7 +15,7 @@ namespace XamlX.IL
     class SreTypeSystem : IXamlTypeSystem
     {
         private List<IXamlAssembly> _assemblies = new List<IXamlAssembly>();
-        public IReadOnlyList<IXamlAssembly> Assemblies => _assemblies;
+        public IEnumerable<IXamlAssembly> Assemblies => EnumerateList(_assemblies);
         
         private Dictionary<Type, SreType> _typeDic = new Dictionary<Type, SreType>();
 
@@ -80,6 +80,12 @@ namespace XamlX.IL
             }
 
             return null;
+        }
+
+        private static IEnumerable<T> EnumerateList<T>(IList<T> list)
+        {
+            for (var c = 0; c < list.Count; c++)
+                yield return list[c];
         }
 
         class SreAssembly : IXamlAssembly

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -130,7 +130,7 @@ namespace XamlX.TypeSystem
 #endif
     interface IXamlTypeSystem
     {
-        IReadOnlyList<IXamlAssembly> Assemblies { get; }
+        IEnumerable<IXamlAssembly> Assemblies { get; }
         IXamlAssembly FindAssembly(string substring);
         IXamlType FindType(string name);
         IXamlType FindType(string name, string assembly);


### PR DESCRIPTION
User reported an issue in main repo: https://github.com/AvaloniaUI/Avalonia/issues/6423
After some investigations, i have realized that issue is related to XamlX.User gets exception on line 23 in ```XamlX.Transform.XamlXmlnsMappings.Resolve```.
What happens? 
In this code during enumeration sometimes we receive CustomAttributes which we didn't have before, which would trigger ResolveType->ResolveAssembly and at that moment collection of assemblies would be modified because we have new CustomAttribute which related to new assembly which we don't have in our Assemblies list. Currently, we only know that this issue happens with ```Microsoft.AspNetCore.Mvc.Versioning```
![image](https://user-images.githubusercontent.com/53405089/132218374-191d9f55-28e4-4e2a-b80a-61b90af642ec.png)
I think it may happen because:
- you did not have the ```SomeAttribute``` type loaded
- you asked attributes of some assembly that has such attribute
- you receive attributes without ```SomeAttribute```
- a little bit later you triggered the loading of the assembly defining this attribute
- this causes a change in the list of attributes on the existing assembly

Newly loaded assemblies are being added to the end of the list so this solution is probably ok