### PR TITLE
Add x:True and x:False intrinsics

### DIFF
--- a/src/XamlX/Ast/Intrinsics.cs
+++ b/src/XamlX/Ast/Intrinsics.cs
@@ -30,27 +30,6 @@ namespace XamlX.Ast
 #if !XAMLX_INTERNAL
     public
 #endif
-    class XamlBoolExtensionNode : XamlAstNode, IXamlAstValueNode, IXamlAstEmitableNode<IXamlILEmitter, XamlILNodeEmitResult>
-    {
-        private readonly bool _value;
-        public XamlBoolExtensionNode(IXamlLineInfo lineInfo, bool value, XamlTypeWellKnownTypes types) : base(lineInfo)
-        {
-            _value = value;
-            Type = new XamlAstClrTypeReference(lineInfo, types.Boolean, false);
-        }
-
-        public IXamlAstTypeReference Type { get; }
-        public XamlILNodeEmitResult Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
-        {
-            // context.Configuration.WellKnownTypes
-            codeGen.Emit(_value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
-            return XamlILNodeEmitResult.Type(0, context.Configuration.WellKnownTypes.Boolean);
-        }
-    }
-
-#if !XAMLX_INTERNAL
-    public
-#endif
     class XamlTypeExtensionNode : XamlAstNode, IXamlAstValueNode, IXamlAstEmitableNode<IXamlILEmitter, XamlILNodeEmitResult>
     {
         private readonly IXamlType _systemType;
@@ -183,6 +162,8 @@ namespace XamlX.Ast
                 codeGen.Emit(OpCodes.Ldc_R4, f);
             else if (Constant is double d)
                 codeGen.Emit(OpCodes.Ldc_R8, d);
+            else if (Constant is bool b)
+                codeGen.Emit(b ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
             else
                 codeGen.Emit(OpCodes.Ldc_I4, TypeSystem.TypeSystemHelpers.ConvertLiteralToInt(Constant));
             return XamlILNodeEmitResult.Type(0, Type.GetClrType());

--- a/src/XamlX/Ast/Intrinsics.cs
+++ b/src/XamlX/Ast/Intrinsics.cs
@@ -30,6 +30,27 @@ namespace XamlX.Ast
 #if !XAMLX_INTERNAL
     public
 #endif
+    class XamlBoolExtensionNode : XamlAstNode, IXamlAstValueNode, IXamlAstEmitableNode<IXamlILEmitter, XamlILNodeEmitResult>
+    {
+        private readonly bool _value;
+        public XamlBoolExtensionNode(IXamlLineInfo lineInfo, bool value, XamlTypeWellKnownTypes types) : base(lineInfo)
+        {
+            _value = value;
+            Type = new XamlAstClrTypeReference(lineInfo, types.Boolean, false);
+        }
+
+        public IXamlAstTypeReference Type { get; }
+        public XamlILNodeEmitResult Emit(XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
+        {
+            // context.Configuration.WellKnownTypes
+            codeGen.Emit(_value ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+            return XamlILNodeEmitResult.Type(0, context.Configuration.WellKnownTypes.Boolean);
+        }
+    }
+
+#if !XAMLX_INTERNAL
+    public
+#endif
     class XamlTypeExtensionNode : XamlAstNode, IXamlAstValueNode, IXamlAstEmitableNode<IXamlILEmitter, XamlILNodeEmitResult>
     {
         private readonly IXamlType _systemType;

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -39,9 +39,9 @@ namespace XamlX.Transform.Transformers
                 if (xml.Name == "Null")
                     return new XamlNullExtensionNode(node);
                 if (xml.Name == "True")
-                    return new XamlBoolExtensionNode(node, true, context.Configuration.WellKnownTypes);
+                    return new XamlConstantNode(node, context.Configuration.WellKnownTypes.Boolean, true);
                 if (xml.Name == "False")
-                    return new XamlBoolExtensionNode(node, false, context.Configuration.WellKnownTypes);
+                    return new XamlConstantNode(node, context.Configuration.WellKnownTypes.Boolean, false);
                 if (xml.Name == "Type")
                 {
                     var textNode = ResolveArgumentOrValue("x:Type", "TypeName");

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -35,9 +35,13 @@ namespace XamlX.Transform.Transformers
                         return (XamlAstTextNode) context.ParseError("x:Type parameter should be a text node", value, node);
                     return textNode;
                 }
-                
+
                 if (xml.Name == "Null")
                     return new XamlNullExtensionNode(node);
+                if (xml.Name == "True")
+                    return new XamlBoolExtensionNode(node, true, context.Configuration.WellKnownTypes);
+                if (xml.Name == "False")
+                    return new XamlBoolExtensionNode(node, false, context.Configuration.WellKnownTypes);
                 if (xml.Name == "Type")
                 {
                     var textNode = ResolveArgumentOrValue("x:Type", "TypeName");

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -10,6 +10,8 @@ namespace XamlParserTests
         public object ObjectProperty { get; set; }
         public int IntProperty { get; set; }
         public Type TypeProperty { get; set; }
+        public bool BoolProperty { get; set; }
+        public bool? NullableBoolProperty { get; set; }
 
         public static object StaticProp { get; } = "StaticPropValue";
         public static object StaticField = "StaticFieldValue";
@@ -17,7 +19,6 @@ namespace XamlParserTests
         public const int IntConstant = 100;
         public const float FloatConstant = 2;
         public const double DoubleConstant = 3;
-        
     }
 
     public enum IntrinsicsTestsEnum : long
@@ -88,6 +89,61 @@ namespace XamlParserTests
         public void Static_Extension_Resolves_Enum_Values()
         {
             Static_Extension_Resolves_Values(IntrinsicsTestsEnum.Foo, "IntrinsicsTestsEnum.Foo");
+        }
+
+        [Theory,
+            InlineData(true, "x:True"),
+            InlineData(false, "x:False")]
+        public void Boolean_Extension_Can_Be_Set_To_Object(bool expected, string value)
+        {
+            var res = (IntrinsicsTestsClass)CompileAndRun($@"
+<IntrinsicsTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <IntrinsicsTestsClass.ObjectProperty><{value}/></IntrinsicsTestsClass.ObjectProperty>
+</IntrinsicsTestsClass>");
+            Assert.Equal(expected, res.ObjectProperty);
+        }
+
+        [Theory,
+            InlineData(true, "x:True"),
+            InlineData(false, "x:False")]
+        public void Boolean_Extension_Can_Be_Set_To_Bool(bool expected, string value)
+        {
+            var res = (IntrinsicsTestsClass)CompileAndRun($@"
+<IntrinsicsTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <IntrinsicsTestsClass.BoolProperty><{value}/></IntrinsicsTestsClass.BoolProperty>
+</IntrinsicsTestsClass>");
+            Assert.Equal(expected, res.BoolProperty);
+        }
+
+        [Theory,
+            InlineData(true, "x:True"),
+            InlineData(false, "x:False")]
+        public void Boolean_Extension_Can_Be_Set_To_NullableBool(bool expected, string value)
+        {
+            var res = (IntrinsicsTestsClass)CompileAndRun($@"
+<IntrinsicsTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <IntrinsicsTestsClass.NullableBoolProperty><{value}/></IntrinsicsTestsClass.NullableBoolProperty>
+</IntrinsicsTestsClass>");
+            Assert.Equal(expected, res.NullableBoolProperty);
+        }
+
+        [Theory,
+            InlineData(true, "x:True"),
+            InlineData(false, "x:False")]
+        public void Boolean_Extension_Can_Be_Used_As_Markup_Ext(bool expected, string value)
+        {
+            var res = (IntrinsicsTestsClass)CompileAndRun($@"
+<IntrinsicsTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                      ObjectProperty='{{{value}}}' />");
+            Assert.Equal(expected, res.ObjectProperty);
+        }
+
+        [Fact]
+        public void Boolean_Extension_Should_Cause_Compilation_Error_When_Applied_To_Wrong_Type()
+        {
+            Assert.Throws<XamlLoadException>(() => Compile(@"
+<IntrinsicsTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+                      IntProperty='{x:True}' />"));
         }
     }
 }


### PR DESCRIPTION
Adds x:True and x:False intrinsics, which can be used with properties where target type is object and boolean cannot be recognized from "True" string. Also works with bool and bool? properties as well.

Common use case
```xml
<Button CommandParameter="{x:True}" />
```