### PR TITLE
fixes: Avalonia Issue #6983

### DIFF
--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -79,7 +79,7 @@ namespace XamlX.Ast
 
         public XamlAstClrProperty(IXamlLineInfo lineInfo, string name, IXamlType declaringType,
             IXamlMethod getter, params IXamlMethod[] setters) : this(lineInfo, name, declaringType,
-            getter, setters.Select(x => new XamlDirectCallPropertySetter(x)))
+            getter, setters.Where(x=> !(x is null)).Select(x => new XamlDirectCallPropertySetter(x)))
         {
 
         }


### PR DESCRIPTION
fixes https://github.com/AvaloniaUI/Avalonia/issues/6983

## Current behavior

When defining  a attached property and making a typo on getter o setter method name, you will be trhow `XAMLIL Internal compiler error while transforming node XamlX.Ast.XamlAstNamePropertyReference`

## Expected behavior

When defining  a attached property and making a typo on getter o setter method name, you will be trhow `Unable to find suitable setter or adder for property {PropertyName} of type {OwnerType} for argument ... {PropertyType}, available setter parameter lists are:...`

 
