### PR TITLE
Add and implement CreateDelegateSubType method on IXamlTypeSystem

### DIFF
--- a/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
@@ -114,6 +114,36 @@ namespace XamlX.TypeSystem
                 return new CecilTypeBuilder(TypeSystem, (CecilAssembly) Assembly, td);
             }
 
+            public IXamlType CreateDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes)
+            {
+                var attrs = TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout;
+                if (isPublic)
+                    attrs |= TypeAttributes.NestedPublic;
+                else
+                    attrs |= TypeAttributes.NestedPrivate;
+
+                var builder = new TypeDefinition("", name, attrs, GetReference(TypeSystem.FindType("System.MulticastDelegate")));
+
+                Definition.NestedTypes.Add(builder);
+
+                var ctor = new MethodDefinition(".ctor", MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig, GetReference(returnType));
+                ctor.ImplAttributes = MethodImplAttributes.Managed | MethodImplAttributes.Runtime;
+                ctor.Parameters.Add(new ParameterDefinition(GetReference(TypeSystem.GetType("System.Object"))));
+                ctor.Parameters.Add(new ParameterDefinition(GetReference(TypeSystem.GetType("System.IntPtr"))));
+
+                builder.Methods.Add(ctor);
+
+                var invoke = new MethodDefinition(".ctor", MethodAttributes.Public | MethodAttributes.HideBySig, GetReference(returnType));
+                invoke.ImplAttributes = MethodImplAttributes.Managed | MethodImplAttributes.Runtime;
+
+                foreach (var param in parameterTypes)
+                {
+                    invoke.Parameters.Add(new ParameterDefinition(GetReference(param)));
+                };
+
+                return new CecilTypeBuilder(TypeSystem, (CecilAssembly)Assembly, builder);
+            }
+
             public void DefineGenericParameters(IReadOnlyList<KeyValuePair<string, XamlGenericParameterConstraint>> args)
             {
                 foreach (var arg in args)

--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -651,7 +651,9 @@ namespace XamlX.Ast
             CompileBuilder(new ILEmitContext(buildMethod.Generator, context.Configuration,
                 context.EmitMappings, runtimeContext: context.RuntimeContext,
                 contextLocal: buildMethod.Generator.DefineLocal(context.RuntimeContext.ContextType),
-                createSubType: (s, type) => subType.DefineSubType(type, s, false), file: context.File,
+                createSubType: (s, type) => subType.DefineSubType(type, s, false),
+                createDelegateSubType: (s, returnType, parameters) => subType.CreateDelegateSubType(s, false, returnType, parameters), 
+                file: context.File,
                 emitters: context.Emitters));
 
             var funcType = Type.GetClrType();

--- a/src/XamlX/Compiler/XamlCompiler.cs
+++ b/src/XamlX/Compiler/XamlCompiler.cs
@@ -80,6 +80,7 @@ namespace XamlX.Compiler
         protected abstract XamlEmitContext<TBackendEmitter, TEmitResult> InitCodeGen(
             IFileSource file,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
             TBackendEmitter codeGen, XamlRuntimeContext<TBackendEmitter, TEmitResult> context, bool needContextLocal);
     }
 }

--- a/src/XamlX/Compiler/XamlImperativeCompiler.cs
+++ b/src/XamlX/Compiler/XamlImperativeCompiler.cs
@@ -70,6 +70,7 @@ namespace XamlX.Compiler
                     typeBuilder.DefineSubType(_configuration.WellKnownTypes.Object,
                         namespaceInfoClassName, false),
                 (name, bt) => typeBuilder.DefineSubType(bt, name, false),
+                (s, returnType, parameters) => typeBuilder.CreateDelegateSubType(s, false, returnType, parameters),
                 baseUri, fileSource);
         }
 
@@ -77,17 +78,18 @@ namespace XamlX.Compiler
             IXamlMethodBuilder<TBackendEmitter> populateMethod, IXamlMethodBuilder<TBackendEmitter> buildMethod,
             IXamlTypeBuilder<TBackendEmitter> namespaceInfoBuilder,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createClosure,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
             string baseUri, IFileSource fileSource)
         {
             var rootGrp = (XamlValueWithManipulationNode)doc.Root;
             var rootType = rootGrp.Type.GetClrType();
             var context = CreateRuntimeContext(doc, contextType, namespaceInfoBuilder, baseUri, rootType);
 
-            CompilePopulate(fileSource, rootGrp.Manipulation, createClosure, populateMethod.Generator, context);
+            CompilePopulate(fileSource, rootGrp.Manipulation, createClosure, createDelegateType, populateMethod.Generator, context);
 
             if (buildMethod != null)
             {
-                CompileBuild(fileSource, rootGrp.Value, null, buildMethod.Generator, context, populateMethod);
+                CompileBuild(fileSource, rootGrp.Value, null, createDelegateType, buildMethod.Generator, context, populateMethod);
             }
 
             namespaceInfoBuilder?.CreateType();
@@ -95,11 +97,13 @@ namespace XamlX.Compiler
 
         protected abstract void CompilePopulate(IFileSource fileSource, IXamlAstManipulationNode manipulation,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
             TBackendEmitter codeGen, XamlRuntimeContext<TBackendEmitter, TEmitResult> context);
 
         protected abstract void CompileBuild(
             IFileSource fileSource,
             IXamlAstValueNode rootInstance, Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
             TBackendEmitter codeGen, XamlRuntimeContext<TBackendEmitter, TEmitResult> context,
             IXamlMethod compiledPopulate);
 

--- a/src/XamlX/Emit/XamlEmitContext.cs
+++ b/src/XamlX/Emit/XamlEmitContext.cs
@@ -31,7 +31,8 @@ namespace XamlX.Emit
             XamlLanguageEmitMappings<TBackendEmitter, TEmitResult> emitMappings,
             XamlRuntimeContext<TBackendEmitter, TEmitResult> runtimeContext,
             IXamlLocal contextLocal,
-            Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType, IFileSource file,
+            Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
+            IFileSource file,
             IEnumerable<object> emitters)
         {
             File = file;

--- a/src/XamlX/Emit/XamlEmitContext.cs
+++ b/src/XamlX/Emit/XamlEmitContext.cs
@@ -25,6 +25,7 @@ namespace XamlX.Emit
         public XamlRuntimeContext<TBackendEmitter, TEmitResult> RuntimeContext { get; }
         public IXamlLocal ContextLocal { get; }
         public Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> CreateSubType { get; }
+        public Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> CreateDelegateSubType { get; }
         public TBackendEmitter Emitter { get; }
 
         public XamlEmitContext(TBackendEmitter emitter, TransformerConfiguration configuration,
@@ -32,6 +33,7 @@ namespace XamlX.Emit
             XamlRuntimeContext<TBackendEmitter, TEmitResult> runtimeContext,
             IXamlLocal contextLocal,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
             IFileSource file,
             IEnumerable<object> emitters)
         {
@@ -42,6 +44,7 @@ namespace XamlX.Emit
             RuntimeContext = runtimeContext;
             ContextLocal = contextLocal;
             CreateSubType = createSubType;
+            CreateDelegateSubType = createDelegateSubType;
             EmitMappings = emitMappings;
         }
 

--- a/src/XamlX/Emit/XamlEmitContextWithLocals.cs
+++ b/src/XamlX/Emit/XamlEmitContextWithLocals.cs
@@ -23,9 +23,10 @@ namespace XamlX.Emit
             XamlRuntimeContext<TBackendEmitter, TEmitResult> runtimeContext,
             IXamlLocal contextLocal,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
             IFileSource file,
             IEnumerable<object> emitters)
-            : base(emitter, configuration, emitMappings, runtimeContext, contextLocal, createSubType, file, emitters)
+            : base(emitter, configuration, emitMappings, runtimeContext, contextLocal, createSubType, createDelegateSubType, file, emitters)
         {
         }
 

--- a/src/XamlX/IL/ILEmitContext.cs
+++ b/src/XamlX/IL/ILEmitContext.cs
@@ -21,9 +21,12 @@ namespace XamlX.IL
             XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult> emitMappings,
             XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> runtimeContext,
             IXamlLocal contextLocal,
-            Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType, IFileSource file, IEnumerable<object> emitters)
+            Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
+            IFileSource file,
+            IEnumerable<object> emitters)
             : base(emitter, configuration, emitMappings, runtimeContext,
-                contextLocal, createSubType, file, emitters)
+                contextLocal, createSubType, createDelegateSubType, file, emitters)
         {
             EnableIlVerification = configuration.GetOrCreateExtra<ILEmitContextSettings>().EnableILVerification;
         }

--- a/src/XamlX/IL/XamlIlCompiler.cs
+++ b/src/XamlX/IL/XamlIlCompiler.cs
@@ -55,6 +55,7 @@ namespace XamlX.IL
         protected override XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> InitCodeGen(
             IFileSource file,
             Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
             IXamlILEmitter codeGen, XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> context,
             bool needContextLocal)
         {
@@ -72,6 +73,7 @@ namespace XamlX.IL
 
             var emitContext = new ILEmitContext(codeGen, _configuration,
                 _emitMappings, context, contextLocal, createSubType,
+                createDelegateSubType,
                 file, Emitters);
             return emitContext;
         }
@@ -79,11 +81,12 @@ namespace XamlX.IL
         protected override void CompileBuild(
             IFileSource fileSource,
             IXamlAstValueNode rootInstance, Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
             IXamlILEmitter codeGen, XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> context,
             IXamlMethod compiledPopulate)
         {
             var needContextLocal = !(rootInstance is XamlAstNewClrObjectNode newObj && newObj.Arguments.Count == 0);
-            var emitContext = InitCodeGen(fileSource, createSubType, codeGen, context, needContextLocal);
+            var emitContext = InitCodeGen(fileSource, createSubType, createDelegateType, codeGen, context, needContextLocal);
 
             var rv = codeGen.DefineLocal(rootInstance.Type.GetClrType());
             emitContext.Emit(rootInstance, codeGen, rootInstance.Type.GetClrType());
@@ -101,11 +104,12 @@ namespace XamlX.IL
         /// </summary>
         protected override void CompilePopulate(IFileSource fileSource, IXamlAstManipulationNode manipulation,
             Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
             IXamlILEmitter codeGen, XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> context)
         {
             // Uncomment to inspect generated IL in debugger
             //codeGen = new RecordingIlEmitter(codeGen);
-            var emitContext = InitCodeGen(fileSource, createSubType, codeGen, context, true);
+            var emitContext = InitCodeGen(fileSource, createSubType, createDelegateType, codeGen, context, true);
 
             codeGen
                 .Emit(OpCodes.Ldloc, emitContext.ContextLocal)

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -176,6 +176,7 @@ namespace XamlX.TypeSystem
         IXamlConstructorBuilder<TBackendEmitter> DefineConstructor(bool isStatic, params IXamlType[] args);
         IXamlType CreateType();
         IXamlTypeBuilder<TBackendEmitter> DefineSubType(IXamlType baseType, string name, bool isPublic);
+        IXamlType CreateDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes);
         void DefineGenericParameters(IReadOnlyList<KeyValuePair<string, XamlGenericParameterConstraint>> names);
     }
 
@@ -193,6 +194,14 @@ namespace XamlX.TypeSystem
     interface IXamlConstructorBuilder<TBackendEmitter> : IXamlConstructor
     {
         TBackendEmitter Generator { get; }
+    }
+
+#if !XAMLX_INTERNAL
+    public
+#endif
+    interface IXamlDelegateTypeBuilder
+    {
+        IXamlType DefineDelegateType(IXamlType returnType, IList<IXamlType> argumentTypes);
     }
 
 #if !XAMLX_INTERNAL


### PR DESCRIPTION
Emitting delegate types requires some additional features that we don't expose through the XamlX type system abstractions.

Instead of exposing those features, I think it's better to instead expose a helper function to emit delegate types themselves as they're uniform in design but also require specific flags on specific methods.

This is a prereq to supporting the "binding to methods" behavior for Avalonia compiled bindings that exists today with reflection bindings.