### PR TITLE
Expose the 'RuntimeImpl' method impl attribute directly.

### DIFF
--- a/src/XamlX.IL.Cecil/CecilMethod.cs
+++ b/src/XamlX.IL.Cecil/CecilMethod.cs
@@ -113,6 +113,22 @@ namespace XamlX.TypeSystem
 
                 return new CecilMethod(TypeSystem, instantiation, _declaringTypeReference);
             }
+
+            public bool IsRuntimeImplemented
+            {
+                get => (Definition.ImplAttributes & MethodImplAttributes.Runtime) != 0;
+                set
+                {
+                    if (value)
+                    {
+                        Definition.ImplAttributes |= MethodImplAttributes.Runtime;
+                    }
+                    else
+                    {
+                        Definition.ImplAttributes = (Definition.ImplAttributes & ~MethodImplAttributes.Runtime);
+                    }
+                }
+            }
         }
         
         [DebuggerDisplay("{" + nameof(Reference) + "}")]
@@ -125,6 +141,22 @@ namespace XamlX.TypeSystem
 
             public bool Equals(IXamlConstructor other) => other is CecilConstructor cm
                                                             && cm.Reference.Equals(Reference);
+
+            public bool IsRuntimeImplemented
+            {
+                get => (Definition.ImplAttributes & MethodImplAttributes.Runtime) != 0;
+                set
+                {
+                    if (value)
+                    {
+                        Definition.ImplAttributes |= MethodImplAttributes.Runtime;
+                    }
+                    else
+                    {
+                        Definition.ImplAttributes = (Definition.ImplAttributes & ~MethodImplAttributes.Runtime);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -334,14 +334,14 @@ namespace XamlX.IL
 
         class SreConstructor : SreMethodBase, IXamlConstructor
         {
-            public ConstructorInfo Constuctor { get; }
+            public ConstructorInfo Constructor { get; }
             public SreConstructor(SreTypeSystem system, ConstructorInfo ctor) : base(system, ctor)
             {
-                Constuctor = ctor;
+                Constructor = ctor;
             }
 
             public bool Equals(IXamlConstructor other) 
-                => ((SreConstructor) other)?.Constuctor.Equals(Constuctor) == true;
+                => ((SreConstructor) other)?.Constructor.Equals(Constructor) == true;
         }
 
         class SreProperty : SreMemberInfo, IXamlProperty
@@ -450,7 +450,7 @@ namespace XamlX.IL
 
             public IXamlILEmitter Emit(OpCode code, IXamlConstructor ctor)
             {
-                _ilg.Emit(code, ((SreConstructor) ctor).Constuctor);
+                _ilg.Emit(code, ((SreConstructor) ctor).Constructor);
                 return this;
             }
 
@@ -595,6 +595,22 @@ namespace XamlX.IL
                 {
                     throw new NotImplementedException();
                 }
+
+                public bool IsRuntimeImplemented
+                {
+                    get => (MethodBuilder.MethodImplementationFlags & MethodImplAttributes.Runtime) != 0;
+                    set
+                    {
+                        if (value)
+                        {
+                            MethodBuilder.SetImplementationFlags(MethodBuilder.MethodImplementationFlags | MethodImplAttributes.Runtime);
+                        }
+                        else
+                        {
+                            MethodBuilder.SetImplementationFlags(MethodBuilder.MethodImplementationFlags & ~MethodImplAttributes.Runtime);
+                        }
+                    }
+                }
             }
             
             public IXamlMethodBuilder<IXamlILEmitter> DefineMethod(IXamlType returnType, IEnumerable<IXamlType> args, string name,
@@ -633,6 +649,21 @@ namespace XamlX.IL
                 }
 
                 public IXamlILEmitter Generator { get; }
+                public bool IsRuntimeImplemented
+                {
+                    get => (Constructor.MethodImplementationFlags & MethodImplAttributes.Runtime) != 0;
+                    set
+                    {
+                        if (value)
+                        {
+                            ((ConstructorBuilder)Constructor).SetImplementationFlags(Constructor.MethodImplementationFlags | MethodImplAttributes.Runtime);
+                        }
+                        else
+                        {
+                            ((ConstructorBuilder)Constructor).SetImplementationFlags(Constructor.MethodImplementationFlags & ~MethodImplAttributes.Runtime);
+                        }
+                    }
+                }
             }
 
             

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -184,6 +184,7 @@ namespace XamlX.TypeSystem
 #endif
     interface IXamlMethodBuilder<TBackendEmitter> : IXamlMethod
     {
+        bool IsRuntimeImplemented { get; set; }
         TBackendEmitter Generator { get; }
     }
 
@@ -192,6 +193,7 @@ namespace XamlX.TypeSystem
 #endif
     interface IXamlConstructorBuilder<TBackendEmitter> : IXamlConstructor
     {
+        bool IsRuntimeImplemented { get; set; }
         TBackendEmitter Generator { get; }
     }
 


### PR DESCRIPTION
As an alternative to #51, expose the 'RuntimeImpl' method impl attribute flag so consumers can manually implement their own delegate-emit infrastructure.