### PR TITLE
Use TypeBuilder for the "create delegate type" operation as SRE requires the "CreateType" call to be after usages in IL emit.

### DIFF
--- a/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
@@ -114,7 +114,7 @@ namespace XamlX.TypeSystem
                 return new CecilTypeBuilder(TypeSystem, (CecilAssembly) Assembly, td);
             }
 
-            public IXamlType CreateDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes)
+            public IXamlTypeBuilder<IXamlILEmitter> DefineDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes)
             {
                 var attrs = TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout;
                 if (isPublic)

--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -652,7 +652,7 @@ namespace XamlX.Ast
                 context.EmitMappings, runtimeContext: context.RuntimeContext,
                 contextLocal: buildMethod.Generator.DefineLocal(context.RuntimeContext.ContextType),
                 createSubType: (s, type) => subType.DefineSubType(type, s, false),
-                createDelegateSubType: (s, returnType, parameters) => subType.CreateDelegateSubType(s, false, returnType, parameters), 
+                defineDelegateSubType: (s, returnType, parameters) => subType.DefineDelegateSubType(s, false, returnType, parameters), 
                 file: context.File,
                 emitters: context.Emitters));
 

--- a/src/XamlX/Compiler/XamlCompiler.cs
+++ b/src/XamlX/Compiler/XamlCompiler.cs
@@ -80,7 +80,7 @@ namespace XamlX.Compiler
         protected abstract XamlEmitContext<TBackendEmitter, TEmitResult> InitCodeGen(
             IFileSource file,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> createDelegateType,
             TBackendEmitter codeGen, XamlRuntimeContext<TBackendEmitter, TEmitResult> context, bool needContextLocal);
     }
 }

--- a/src/XamlX/Compiler/XamlImperativeCompiler.cs
+++ b/src/XamlX/Compiler/XamlImperativeCompiler.cs
@@ -70,7 +70,7 @@ namespace XamlX.Compiler
                     typeBuilder.DefineSubType(_configuration.WellKnownTypes.Object,
                         namespaceInfoClassName, false),
                 (name, bt) => typeBuilder.DefineSubType(bt, name, false),
-                (s, returnType, parameters) => typeBuilder.CreateDelegateSubType(s, false, returnType, parameters),
+                (s, returnType, parameters) => typeBuilder.DefineDelegateSubType(s, false, returnType, parameters),
                 baseUri, fileSource);
         }
 
@@ -78,7 +78,7 @@ namespace XamlX.Compiler
             IXamlMethodBuilder<TBackendEmitter> populateMethod, IXamlMethodBuilder<TBackendEmitter> buildMethod,
             IXamlTypeBuilder<TBackendEmitter> namespaceInfoBuilder,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createClosure,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> createDelegateType,
             string baseUri, IFileSource fileSource)
         {
             var rootGrp = (XamlValueWithManipulationNode)doc.Root;
@@ -97,13 +97,13 @@ namespace XamlX.Compiler
 
         protected abstract void CompilePopulate(IFileSource fileSource, IXamlAstManipulationNode manipulation,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> DefineDelegateSubType,
             TBackendEmitter codeGen, XamlRuntimeContext<TBackendEmitter, TEmitResult> context);
 
         protected abstract void CompileBuild(
             IFileSource fileSource,
             IXamlAstValueNode rootInstance, Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> createDelegateType,
             TBackendEmitter codeGen, XamlRuntimeContext<TBackendEmitter, TEmitResult> context,
             IXamlMethod compiledPopulate);
 

--- a/src/XamlX/Emit/XamlEmitContext.cs
+++ b/src/XamlX/Emit/XamlEmitContext.cs
@@ -25,7 +25,7 @@ namespace XamlX.Emit
         public XamlRuntimeContext<TBackendEmitter, TEmitResult> RuntimeContext { get; }
         public IXamlLocal ContextLocal { get; }
         public Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> CreateSubType { get; }
-        public Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> CreateDelegateSubType { get; }
+        public Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> DefineDelegateSubType { get; }
         public TBackendEmitter Emitter { get; }
 
         public XamlEmitContext(TBackendEmitter emitter, TransformerConfiguration configuration,
@@ -33,7 +33,7 @@ namespace XamlX.Emit
             XamlRuntimeContext<TBackendEmitter, TEmitResult> runtimeContext,
             IXamlLocal contextLocal,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> defineDelegateSubType,
             IFileSource file,
             IEnumerable<object> emitters)
         {
@@ -44,7 +44,7 @@ namespace XamlX.Emit
             RuntimeContext = runtimeContext;
             ContextLocal = contextLocal;
             CreateSubType = createSubType;
-            CreateDelegateSubType = createDelegateSubType;
+            DefineDelegateSubType = defineDelegateSubType;
             EmitMappings = emitMappings;
         }
 

--- a/src/XamlX/Emit/XamlEmitContextWithLocals.cs
+++ b/src/XamlX/Emit/XamlEmitContextWithLocals.cs
@@ -23,10 +23,10 @@ namespace XamlX.Emit
             XamlRuntimeContext<TBackendEmitter, TEmitResult> runtimeContext,
             IXamlLocal contextLocal,
             Func<string, IXamlType, IXamlTypeBuilder<TBackendEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<TBackendEmitter>> defineDelegateSubType,
             IFileSource file,
             IEnumerable<object> emitters)
-            : base(emitter, configuration, emitMappings, runtimeContext, contextLocal, createSubType, createDelegateSubType, file, emitters)
+            : base(emitter, configuration, emitMappings, runtimeContext, contextLocal, createSubType, defineDelegateSubType, file, emitters)
         {
         }
 

--- a/src/XamlX/IL/ILEmitContext.cs
+++ b/src/XamlX/IL/ILEmitContext.cs
@@ -22,11 +22,11 @@ namespace XamlX.IL
             XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> runtimeContext,
             IXamlLocal contextLocal,
             Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<IXamlILEmitter>> defineDelegateSubType,
             IFileSource file,
             IEnumerable<object> emitters)
             : base(emitter, configuration, emitMappings, runtimeContext,
-                contextLocal, createSubType, createDelegateSubType, file, emitters)
+                contextLocal, createSubType, defineDelegateSubType, file, emitters)
         {
             EnableIlVerification = configuration.GetOrCreateExtra<ILEmitContextSettings>().EnableILVerification;
         }

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -662,7 +662,7 @@ namespace XamlX.IL
                 return new SreTypeBuilder(_system, builder);
             }
 
-            public IXamlType CreateDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes)
+            public IXamlTypeBuilder<IXamlILEmitter> DefineDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes)
             {
                 var attrs = TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoLayout;
                 if (isPublic)
@@ -681,7 +681,7 @@ namespace XamlX.IL
                     parameterTypes.Select(p => ((SreType)p).Type).ToArray())
                     .SetImplementationFlags(MethodImplAttributes.Managed | MethodImplAttributes.Runtime);
 
-                return new SreType(_system, null, builder.CreateTypeInfo());
+                return new SreTypeBuilder(_system, builder);
             }
 
             public void DefineGenericParameters(IReadOnlyList<KeyValuePair<string, XamlGenericParameterConstraint>> args)

--- a/src/XamlX/IL/XamlIlCompiler.cs
+++ b/src/XamlX/IL/XamlIlCompiler.cs
@@ -55,7 +55,7 @@ namespace XamlX.IL
         protected override XamlEmitContext<IXamlILEmitter, XamlILNodeEmitResult> InitCodeGen(
             IFileSource file,
             Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateSubType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<IXamlILEmitter>> defineDelegateSubType,
             IXamlILEmitter codeGen, XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> context,
             bool needContextLocal)
         {
@@ -73,7 +73,7 @@ namespace XamlX.IL
 
             var emitContext = new ILEmitContext(codeGen, _configuration,
                 _emitMappings, context, contextLocal, createSubType,
-                createDelegateSubType,
+                defineDelegateSubType,
                 file, Emitters);
             return emitContext;
         }
@@ -81,7 +81,7 @@ namespace XamlX.IL
         protected override void CompileBuild(
             IFileSource fileSource,
             IXamlAstValueNode rootInstance, Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
+            Func<string, IXamlType, IEnumerable<IXamlType>,  IXamlTypeBuilder<IXamlILEmitter>> createDelegateType,
             IXamlILEmitter codeGen, XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> context,
             IXamlMethod compiledPopulate)
         {
@@ -104,7 +104,7 @@ namespace XamlX.IL
         /// </summary>
         protected override void CompilePopulate(IFileSource fileSource, IXamlAstManipulationNode manipulation,
             Func<string, IXamlType, IXamlTypeBuilder<IXamlILEmitter>> createSubType,
-            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlType> createDelegateType,
+            Func<string, IXamlType, IEnumerable<IXamlType>, IXamlTypeBuilder<IXamlILEmitter>> createDelegateType,
             IXamlILEmitter codeGen, XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> context)
         {
             // Uncomment to inspect generated IL in debugger

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -176,7 +176,7 @@ namespace XamlX.TypeSystem
         IXamlConstructorBuilder<TBackendEmitter> DefineConstructor(bool isStatic, params IXamlType[] args);
         IXamlType CreateType();
         IXamlTypeBuilder<TBackendEmitter> DefineSubType(IXamlType baseType, string name, bool isPublic);
-        IXamlType CreateDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes);
+        IXamlTypeBuilder<TBackendEmitter> DefineDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes);
         void DefineGenericParameters(IReadOnlyList<KeyValuePair<string, XamlGenericParameterConstraint>> names);
     }
 


### PR DESCRIPTION
This is a follow-up to #51 to change the design of the "create delegate type" operation to return an `IXamlTypeBuilder<>` so that the correct order of operations can be done when using the SRE backend.