### PR TITLE
Use correct setters in property assignment emitter.

### DIFF
--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -51,7 +51,7 @@ namespace XamlX.IL.Emitters
             // If there is only one available setter or if value is a value type, always use the first one
             if (setters.Count == 1 || isValueType)
             {
-                var setter = an.PossibleSetters.First();
+                var setter = setters[0];
                 context.Emit(value, codeGen, setter.Parameters.Last());
                 context.Emit(setter, codeGen);
             }


### PR DESCRIPTION
The `PropertyAssignmentEmitter` checked that `setters.Count` is 1 and then proceeded to get the setter from the unfiltered collection, meaning that the wrong setter could be chosen.