### PR TITLE
Introduce IAddChild

### DIFF
--- a/src/XamlX/Transform/XamlLanguageTypeMappings.cs
+++ b/src/XamlX/Transform/XamlLanguageTypeMappings.cs
@@ -45,7 +45,9 @@ namespace XamlX.Transform
         public IXamlType ParentStackProvider { get; set; }
         public IXamlType XmlNamespaceInfoProvider { get; set; }
         public IXamlType UriContextProvider { get; set; }
-        
+        public IXamlType IAddChild { get; set; }
+        public IXamlType IAddChildOfT { get; set; }
+
         public IXamlCustomAttributeResolver CustomAttributeResolver { get; set; }
         
         /// <summary>

--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -63,6 +63,24 @@ namespace XamlX.Transform
                     if (!rv[c].ThisOrFirstParameter().Equals(type))
                         rv[c] = new XamlMethodWithCasts(rv[c], new[] {type}.Concat(rv[c].Parameters));
 
+                var addChildT = inspectTypes.Where(t => t.GenericTypeDefinition?.Equals(context.Configuration.TypeMappings.IAddChildOfT) == true);
+
+                foreach (var t in addChildT)
+                {
+                    var adder = t.FindMethod(x => x.Name == "AddChild");
+
+                    rv.Add(adder);
+                }
+
+                var addChild = inspectTypes.SingleOrDefault(t => t.Equals(context.Configuration.TypeMappings.IAddChild) == true);
+
+                if (addChild != null)
+                {
+                    var adder = addChild.FindMethod(x => x.Name == "AddChild");
+
+                    rv.Add(adder);
+                }
+
                 return rv;
             }
             

--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -63,23 +63,29 @@ namespace XamlX.Transform
                     if (!rv[c].ThisOrFirstParameter().Equals(type))
                         rv[c] = new XamlMethodWithCasts(rv[c], new[] {type}.Concat(rv[c].Parameters));
 
-                var addChildT = inspectTypes.Where(t => t.GenericTypeDefinition?.Equals(context.Configuration.TypeMappings.IAddChildOfT) == true);
-
-                foreach (var t in addChildT)
+                if(context.Configuration.TypeMappings.IAddChildOfT != null)
                 {
-                    var adder = t.FindMethod(x => x.Name == "AddChild");
+                    var addChildT = inspectTypes.Where(t => t.GenericTypeDefinition?.Equals(context.Configuration.TypeMappings.IAddChildOfT) == true);
 
-                    rv.Add(adder);
+                    foreach (var t in addChildT)
+                    {
+                        var adder = t.FindMethod(x => x.Name == "AddChild");
+
+                        rv.Add(adder);
+                    }
                 }
 
-                var addChild = inspectTypes.SingleOrDefault(t => t.Equals(context.Configuration.TypeMappings.IAddChild) == true);
-
-                if (addChild != null)
+                if(context.Configuration.TypeMappings.IAddChild != null)
                 {
-                    var adder = addChild.FindMethod(x => x.Name == "AddChild");
+                    var addChild = inspectTypes.SingleOrDefault(t => t.Equals(context.Configuration.TypeMappings.IAddChild) == true);
 
-                    rv.Add(adder);
-                }
+                    if (addChild != null)
+                    {
+                        var adder = addChild.FindMethod(x => x.Name == "AddChild");
+
+                        rv.Add(adder);
+                    }
+                }              
 
                 return rv;
             }

--- a/tests/XamlParserTests/BasicCompilerTests.cs
+++ b/tests/XamlParserTests/BasicCompilerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using XamlX;
 using Xunit;
 
 namespace XamlParserTests
@@ -17,6 +18,33 @@ namespace XamlParserTests
         public string Test { get; set; }
     }
     
+    public class ObjectWithAddChild : IAddChild
+    {
+        public object Child { get; private set; }
+
+        void IAddChild.AddChild(object child)
+        {
+            Child = child;
+        }
+    }
+
+    public class ObjectWithGenericAddChild : IAddChild<string>
+    {
+        public object Child { get; private set; }
+
+        public string Text { get; private set; }
+
+        void IAddChild.AddChild(object child)
+        {
+            Child = child;
+        }
+
+        void IAddChild<string>.AddChild(string text)
+        {
+            Text = text;
+        }
+    }
+
     public class BasicCompilerTests : CompilerTestBase
     {
         [Theory,
@@ -40,8 +68,32 @@ namespace XamlParserTests
             Assert.Equal("321", res.Test2);
             Assert.Equal("test", res.Children[0].Test);
             Assert.Equal("test2", res.Children[1].Test);
+        }    
+
+        [Fact]
+        public void Compiler_Should_Compile_Xaml_With_IAddChild()
+        {
+            var comp = Compile(@"<ObjectWithAddChild xmlns='test'  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>123</ObjectWithAddChild>");
+
+            var res = (ObjectWithAddChild)comp.create(null);
+
+            comp.populate(null, res);
+
+            Assert.Equal("123", res.Child);
+        }
+
+        [Fact]
+        public void Compiler_Should_Compile_Xaml_With_Generic_IAddChild()
+        {
+            var comp = Compile(@"<ObjectWithGenericAddChild xmlns='test'  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>123</ObjectWithGenericAddChild>");
+
+            var res = (ObjectWithGenericAddChild)comp.create(null);
+
+            comp.populate(null, res);
+
+            Assert.Null(res.Child);
+
+            Assert.Equal("123", res.Text);
         }
     }
-
-
 }

--- a/tests/XamlParserTests/CompilerTestBase.cs
+++ b/tests/XamlParserTests/CompilerTestBase.cs
@@ -54,9 +54,11 @@ namespace XamlParserTests
                     UriContextProvider = typeSystem.GetType("XamlParserTests.ITestUriContext"),
                     ProvideValueTarget = typeSystem.GetType("XamlParserTests.ITestProvideValueTarget"),
                     ParentStackProvider = typeSystem.GetType("XamlX.Runtime.IXamlParentStackProviderV1"),
-                    XmlNamespaceInfoProvider = typeSystem.GetType("XamlX.Runtime.IXamlXmlNamespaceInfoProviderV1")
+                    XmlNamespaceInfoProvider = typeSystem.GetType("XamlX.Runtime.IXamlXmlNamespaceInfoProviderV1"),
+                    IAddChild = typeSystem.GetType("XamlParserTests.IAddChild"),
+                    IAddChildOfT = typeSystem.GetType("XamlParserTests.IAddChild`1")
                 }
-            );
+            ); ;
         }
 
         protected object CompileAndRun(string xaml, IServiceProvider prov = null) => Compile(xaml).create(prov);

--- a/tests/XamlParserTests/TestXamlLanguage.cs
+++ b/tests/XamlParserTests/TestXamlLanguage.cs
@@ -5,6 +5,16 @@ using XamlParserTests;
 [assembly: XmlnsDefinition("test", "XamlParserTests")]
 namespace XamlParserTests
 {
+    public interface IAddChild
+    {
+        void AddChild(object child);
+    }
+
+    public interface IAddChild<T> : IAddChild
+    {
+        void AddChild(T child);
+    }
+
     public class ContentAttribute : Attribute
     {
         


### PR DESCRIPTION
A port of: https://github.com/dotnet/wpf/blob/main/src/Microsoft.DotNet.Wpf/src/PresentationCore/System/Windows/Markup/IAddChild.cs

This helps to hide adders from the public API surface