### PR TITLE
Reduce generated IL code size

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,11 @@
 <Project>
+
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
+
 </Project>

--- a/src/XamlX.IL.Cecil/CecilEmitter.cs
+++ b/src/XamlX.IL.Cecil/CecilEmitter.cs
@@ -132,6 +132,12 @@ namespace XamlX.TypeSystem
 
             public IXamlILEmitter Emit(SreOpCode code, long arg)
                 => Emit(Instruction.Create(Dic[code], arg));
+            
+            public IXamlILEmitter Emit(SreOpCode code, sbyte arg)
+                => Emit(Instruction.Create(Dic[code], arg));
+            
+            public IXamlILEmitter Emit(SreOpCode code, byte arg)
+                => Emit(Instruction.Create(Dic[code], arg));
 
             public IXamlILEmitter Emit(SreOpCode code, IXamlType type)
                 => Emit(Instruction.Create(Dic[code], Import(((ITypeReference) type).Reference)));
@@ -143,9 +149,11 @@ namespace XamlX.TypeSystem
                 => Emit(Instruction.Create(Dic[code], arg));
 
 
-            class CecilLocal : IXamlLocal
+            class CecilLocal : IXamlILLocal
             {
                 public VariableDefinition Variable { get; set; }
+
+                public int Index => Variable.Index;
             }
 
             class CecilLabel : IXamlLabel

--- a/src/XamlX.IL.Cecil/CecilField.cs
+++ b/src/XamlX.IL.Cecil/CecilField.cs
@@ -19,7 +19,9 @@ namespace XamlX.TypeSystem
                 Field = new FieldReference(def.Name, def.FieldType, declaringType);
             }
 
-            public bool Equals(IXamlField other) => other is CecilField cf && cf.Field == Field;
+            public bool Equals(IXamlField other) => other is CecilField cf && cf.Field.FullName == Field.FullName;
+
+            public override int GetHashCode() => Field.FullName.GetHashCode();
 
             public string Name => Field.Name;
             private IXamlType _type;

--- a/src/XamlX.IL.Cecil/CecilMethod.cs
+++ b/src/XamlX.IL.Cecil/CecilMethod.cs
@@ -102,6 +102,9 @@ namespace XamlX.TypeSystem
                 && DeclaringType.Equals(cm.DeclaringType)
                 && Reference.FullName == cm.Reference.FullName;
 
+            public override int GetHashCode() 
+                => (DeclaringType.GetHashCode() * 397) ^ Reference.FullName.GetHashCode();
+
             public IXamlMethod MakeGenericMethod(IReadOnlyList<IXamlType> typeArguments)
             {
                 GenericInstanceMethod instantiation = new GenericInstanceMethod(Reference);

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -112,10 +112,9 @@ namespace XamlX.TypeSystem
             }
             bool IsAssignableFromCore(IXamlType type)
             {
-                if (!type.IsValueType
-                    && type == XamlPseudoType.Null)
-                    return true;
-                
+                if (type == XamlPseudoType.Null)
+                    return !IsValueType || GenericTypeDefinition?.FullName == "System.Nullable`1";
+
                 if (type.IsValueType 
                     && GenericTypeDefinition?.FullName == "System.Nullable`1"
                     && GenericArguments[0].Equals(type))

--- a/src/XamlX/Ast/Intrinsics.cs
+++ b/src/XamlX/Ast/Intrinsics.cs
@@ -165,7 +165,7 @@ namespace XamlX.Ast
             else if (Constant is bool b)
                 codeGen.Emit(b ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
             else
-                codeGen.Emit(OpCodes.Ldc_I4, TypeSystem.TypeSystemHelpers.ConvertLiteralToInt(Constant));
+                codeGen.Ldc_I4(TypeSystem.TypeSystemHelpers.ConvertLiteralToInt(Constant));
             return XamlILNodeEmitResult.Type(0, Type.GetClrType());
         }
     }

--- a/src/XamlX/Emit/XamlEmitContext.cs
+++ b/src/XamlX/Emit/XamlEmitContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using XamlX.Ast;
 using XamlX.Transform;
@@ -18,6 +17,7 @@ namespace XamlX.Emit
         public IFileSource File { get; }
         public List<object> Emitters { get; }
 
+        private readonly List<Action> _afterEmitCallbacks = new();
         private IXamlAstNode _currentNode;
 
         public TransformerConfiguration Configuration { get; }
@@ -216,6 +216,17 @@ namespace XamlX.Emit
 
             foundEmitter = false;
             return res;
+        }
+
+        public void AddAfterEmitCallbacks(Action callback)
+            => _afterEmitCallbacks.Add(callback);
+
+        public void ExecuteAfterEmitCallbacks()
+        {
+            foreach (var callback in _afterEmitCallbacks)
+                callback();
+
+            _afterEmitCallbacks.Clear();
         }
     }
 

--- a/src/XamlX/IL/CheckingIlEmitter.cs
+++ b/src/XamlX/IL/CheckingIlEmitter.cs
@@ -238,6 +238,20 @@ namespace XamlX.IL
             return this;
         }
 
+        public IXamlILEmitter Emit(OpCode code, sbyte arg)
+        {
+            Track(code, arg);
+            _inner.Emit(code, arg);
+            return this;
+        }
+        
+        public IXamlILEmitter Emit(OpCode code, byte arg)
+        {
+            Track(code, arg);
+            _inner.Emit(code, arg);
+            return this;
+        }
+
         public IXamlILEmitter Emit(OpCode code, IXamlType type)
         {
             Track(code, type);

--- a/src/XamlX/IL/Emitters/MarkupExtensionEmitter.cs
+++ b/src/XamlX/IL/Emitters/MarkupExtensionEmitter.cs
@@ -36,7 +36,7 @@ namespace XamlX.IL.Emitters
             
             if (me.ProvideValue.Parameters.Count > 0)
                 ilgen
-                    .Emit(OpCodes.Ldloc, context.ContextLocal);
+                    .Ldloc(context.ContextLocal);
 
             if (needProvideValueTarget)
             {

--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -98,13 +98,16 @@ namespace XamlX.IL.Emitters
                             .Dup()
                             .Isinst(type)
                             .Brfalse(Next());
+                        
+                        if (type.IsValueType)
+                            codeGen.Unbox_Any(type);
+                        
                         checkNext = true;
                     }
 
                     if (checkNext)
                         hadJumps = true;
-                    
-                    ILEmitHelpers.EmitConvert(context, codeGen, value, value.Type.GetClrType(), type);
+
                     context.Emit(setter, codeGen);
                     if (hadJumps)
                     {

--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -1,9 +1,8 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Emit;
 using XamlX.Ast;
 using XamlX.Emit;
-using XamlX.Transform;
 using XamlX.TypeSystem;
 
 namespace XamlX.IL.Emitters
@@ -33,117 +32,271 @@ namespace XamlX.IL.Emitters
                 throw new XamlLoadException("No setters found for property assignment", an);
             return lst;
         }
-        
+
         public XamlILNodeEmitResult Emit(IXamlAstNode node, XamlEmitContextWithLocals<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter codeGen)
         {
-            if (!(node is XamlPropertyAssignmentNode an))
+            if (node is not XamlPropertyAssignmentNode an)
                 return null;
 
             var setters = ValidateAndGetSetters(an);
             for (var c = 0; c < an.Values.Count - 1; c++)
-            {
                 context.Emit(an.Values[c], codeGen, an.Values[c].Type.GetClrType());
-            }
 
-            var value = an.Values.Last();
-            
-            var isValueType = value.Type.GetClrType().IsValueType;
-            // If there is only one available setter or if value is a value type, always use the first one
-            if (setters.Count == 1 || isValueType)
+            var dynamicValue = an.Values.Last();
+            var dynamicValueType = dynamicValue.Type.GetClrType();
+
+            RemoveRedundantSetters(dynamicValueType, setters);
+
+            if (setters.Count == 1)
             {
                 var setter = setters[0];
-                context.Emit(value, codeGen, setter.Parameters.Last());
+                context.Emit(dynamicValue, codeGen, setter.Parameters.Last());
                 context.Emit(setter, codeGen);
             }
             else
             {
-                var checkedTypes = new List<IXamlType>();
-                IXamlLabel exit = codeGen.DefineLabel();
-                IXamlLabel next = null;
-                var hadJumps = false;
-                context.Emit(value, codeGen, value.Type.GetClrType());
-                
-                foreach (var setter in setters)
+                var valueTypes = an.Values.Select(x => x.Type.GetClrType()).ToArray();
+                var method = GetOrCreateDynamicSetterMethod(an.Property.DeclaringType, valueTypes, setters, context);
+                context.Emit(dynamicValue, codeGen, dynamicValueType);
+                codeGen.EmitCall(method);
+            }
+
+            return XamlILNodeEmitResult.Void(1);
+        }
+
+        private static void RemoveRedundantSetters(IXamlType valueType, List<IXamlPropertySetter> setters)
+        {
+            if (setters.Count == 1)
+                return;
+
+            // If the value is a value type, always use the first one
+            if (valueType.IsValueType)
+            {
+                setters.RemoveRange(1, setters.Count - 1);
+                return;
+            }
+
+            for (int index = 0; index < setters.Count;)
+            {
+                var setter = setters[index];
+                var type = setter.Parameters.Last();
+
+                // the value is directly assignable by downcast and the setter allows null: it will always match
+                if (type.IsAssignableFrom(valueType) && setter.BinderParameters.AllowRuntimeNull)
                 {
-                    var type = setter.Parameters.Last();
-                    
-                    // We have already checked this type or its base type
-                    if (checkedTypes.Any(ch => ch.IsAssignableFrom(type)))
-                        continue;
+                    setters.RemoveRange(index + 1, setters.Count - index - 1);
+                    return;
+                }
 
-                    if (next != null)
-                    {
-                        codeGen.MarkLabel(next);
-                        next = null;
-                    }
+                // the value type has already been handled by a previous setter
+                if (setters.Take(index).Any(previous => IsAssignableToWithNullability(setter, previous)))
+                {
+                    setters.RemoveAt(index);
+                    continue;
+                }
 
-                    IXamlLabel Next() => next ?? (next = codeGen.DefineLabel());
+                ++index;
+            }
+        }
 
-                    var checkNext = false;
-                    if (setter.BinderParameters.AllowRuntimeNull)
-                        checkedTypes.Add(type);
-                    else
-                    {
-                        // Check for null; Also don't add this type to the list of checked ones because of the null check
-                        codeGen
-                            .Dup()
-                            .Brfalse(Next());
-                        checkNext = true;
-                    }
+        private static bool IsAssignableToWithNullability(IXamlPropertySetter from, IXamlPropertySetter to)
+            => to.Parameters.Last().IsAssignableFrom(from.Parameters.Last())
+               && (to.BinderParameters.AllowRuntimeNull || !from.BinderParameters.AllowRuntimeNull);
 
-                    // Only do dynamic checks if we know that type is not assignable by downcast 
-                    if (!type.IsAssignableFrom(value.Type.GetClrType()))
-                    {
-                        codeGen
-                            .Dup()
-                            .Isinst(type)
-                            .Brfalse(Next());
-                        
-                        if (type.IsValueType)
-                            codeGen.Unbox_Any(type);
-                        
-                        checkNext = true;
-                    }
+        private static IXamlMethod GetOrCreateDynamicSetterMethod(
+            IXamlType parentType,
+            IReadOnlyList<IXamlType> valueTypes,
+            IReadOnlyList<IXamlPropertySetter> setters,
+            XamlEmitContextWithLocals<IXamlILEmitter, XamlILNodeEmitResult> context)
+        {
+            if (!context.TryGetItem(out DynamicSettersCache cache))
+            {
+                var settersType = context.CreateSubType(
+                    "DynamicSetters_" + context.Configuration.IdentifierGenerator.GenerateIdentifierPart(),
+                    context.Configuration.WellKnownTypes.Object);
+                cache = new DynamicSettersCache(settersType);
+                context.SetItem(cache);
+                context.AddAfterEmitCallbacks(() => settersType.CreateType());
+            }
 
-                    if (checkNext)
-                        hadJumps = true;
+            var cacheKey = new SettersCacheKey(parentType, valueTypes, setters);
 
-                    context.Emit(setter, codeGen);
-                    if (hadJumps)
-                    {
-                        codeGen.Br(exit);
-                    }
+            if (!cache.MethodByCacheKey.TryGetValue(cacheKey, out var method))
+            {
+                method = cache.SettersType.DefineMethod(
+                    context.Configuration.WellKnownTypes.Void,
+                    new[] { parentType }.Concat(valueTypes),
+                    "DynamicSetter_" + (cache.MethodByCacheKey.Count + 1),
+                    true, true, false);
 
-                    if(!checkNext)
-                        break;
+                var newContext = new ILEmitContext(
+                    method.Generator, context.Configuration, context.EmitMappings, context.RuntimeContext,
+                    null,
+                    (s, type) => cache.SettersType.DefineSubType(type, s, false),
+                    (s, returnType, parameters) => cache.SettersType.DefineDelegateSubType(s, false, returnType, parameters),
+                    context.File,
+                    context.Emitters);
+
+                EmitDynamicSetterMethod(valueTypes, setters, newContext);
+
+                cache.MethodByCacheKey[cacheKey] = method;
+            }
+
+            return method;
+        }
+
+        private static void EmitDynamicSetterMethod(
+            IReadOnlyList<IXamlType> valueTypes,
+            IReadOnlyList<IXamlPropertySetter> setters,
+            XamlEmitContextWithLocals<IXamlILEmitter, XamlILNodeEmitResult> context)
+        {
+            var codeGen = context.Emitter;
+
+            codeGen.Ldarg_0();
+            for (int i = 0; i < valueTypes.Count; ++i)
+                codeGen.Ldarg(i + 1);
+
+            var dynamicValueType = valueTypes.Last();
+            IXamlLabel firstAllowingNull = null;
+            IXamlLabel next = null;
+
+            foreach (var setter in setters)
+            {
+                if (next != null)
+                {
+                    codeGen.MarkLabel(next);
+                    next = null;
+                }
+
+                // Only do dynamic checks if we know that type is not assignable by downcast
+                var type = setter.Parameters.Last();
+                if (!type.IsAssignableFrom(dynamicValueType))
+                {
+                    next = codeGen.DefineLabel();
+
+                    codeGen
+                        .Dup()
+                        .Isinst(type)
+                        .Brfalse(next);
+
+                    if (type.IsValueType)
+                        codeGen.Unbox_Any(type);
+                }
+                else if (!setter.BinderParameters.AllowRuntimeNull)
+                {
+                    next = codeGen.DefineLabel();
+
+                    codeGen
+                        .Dup()
+                        .Brfalse(next);
                 }
 
                 if (next != null)
                 {
-                    codeGen.MarkLabel(next);
-
-                    if (setters.Any(x => !x.BinderParameters.AllowRuntimeNull))
+                    if (setter.BinderParameters.AllowRuntimeNull && firstAllowingNull == null)
                     {
-                        next = codeGen.DefineLabel();
-                        codeGen
-                            .Dup()
-                            .Brtrue(next)
-                            .Newobj(context.Configuration.TypeSystem.GetType("System.NullReferenceException")
-                                .FindConstructor())
-                            .Throw();
-                        codeGen.MarkLabel(next);
+                        firstAllowingNull = codeGen.DefineLabel();
+                        codeGen.MarkLabel(firstAllowingNull);
                     }
-
-                    codeGen
-                        .Newobj(context.Configuration.TypeSystem.GetType("System.InvalidCastException")
-                            .FindConstructor())
-                        .Throw();
                 }
 
-                codeGen.MarkLabel(exit);
+                context.Emit(setter, codeGen);
+                codeGen.Ret();
+
+                if (next == null)
+                    break;
             }
 
-            return XamlILNodeEmitResult.Void(1);
+            if (next != null)
+            {
+                codeGen.MarkLabel(next);
+
+                // the value didn't match any type, but it may be null, if so jump to the first setter allowing null
+                if (firstAllowingNull != null)
+                {
+                    codeGen
+                        .Dup()
+                        .Brfalse(firstAllowingNull);
+                }
+                else
+                {
+                    next = codeGen.DefineLabel();
+                    codeGen
+                        .Dup()
+                        .Brtrue(next)
+                        .Newobj(context.Configuration.TypeSystem.GetType("System.NullReferenceException")
+                            .FindConstructor())
+                        .Throw();
+                    codeGen.MarkLabel(next);
+                }
+
+                codeGen
+                    .Newobj(context.Configuration.TypeSystem.GetType("System.InvalidCastException")
+                        .FindConstructor())
+                    .Throw();
+            }
+        }
+
+        private readonly struct SettersCacheKey : IEquatable<SettersCacheKey>
+        {
+            public IXamlType ParentType { get; }
+            public IReadOnlyList<IXamlType> ValueTypes { get; }
+            public IReadOnlyList<IXamlPropertySetter> Setters { get; }
+
+            private static int GetListHashCode<T>(IReadOnlyList<T> list)
+            {
+                int hashCode = list.Count;
+                for (var i = 0; i < list.Count; ++i)
+                    hashCode = (hashCode * 397) ^ list[i].GetHashCode();
+                return hashCode;
+            }
+
+            private static bool AreListEqual<T>(IReadOnlyList<T> x, IReadOnlyList<T> y)
+            {
+                if (x.Count != y.Count)
+                    return false;
+
+                for (var i = 0; i < x.Count; ++i)
+                {
+                    if (!EqualityComparer<T>.Default.Equals(x[i], y[i]))
+                        return false;
+                }
+
+                return true;
+            }
+
+            public bool Equals(SettersCacheKey other)
+                => ParentType == other.ParentType
+                   && AreListEqual(ValueTypes, other.ValueTypes)
+                   && AreListEqual(Setters, other.Setters);
+
+            public override bool Equals(object obj)
+                => obj is SettersCacheKey other && Equals(other);
+
+            public override int GetHashCode()
+            {
+                var hashCode = ParentType.GetHashCode();
+                hashCode = (hashCode * 397) ^ GetListHashCode(ValueTypes);
+                hashCode = (hashCode * 397) ^ GetListHashCode(Setters);
+                return hashCode;
+            }
+
+            public SettersCacheKey(IXamlType parentType, IReadOnlyList<IXamlType> valueTypes, IReadOnlyList<IXamlPropertySetter> setters)
+            {
+                ParentType = parentType;
+                ValueTypes = valueTypes;
+                Setters = setters;
+            }
+        }
+
+        private sealed class DynamicSettersCache
+        {
+            public IXamlTypeBuilder<IXamlILEmitter> SettersType { get; }
+
+            public Dictionary<SettersCacheKey, IXamlMethodBuilder<IXamlILEmitter>> MethodByCacheKey { get; } = new();
+
+            public DynamicSettersCache(IXamlTypeBuilder<IXamlILEmitter> settersType)
+                => SettersType = settersType;
         }
     }
 }

--- a/src/XamlX/IL/ILEmitContext.cs
+++ b/src/XamlX/IL/ILEmitContext.cs
@@ -97,7 +97,7 @@ namespace XamlX.IL
         public override void LoadLocalValue(XamlAstCompilerLocalNode node, IXamlILEmitter codeGen)
         {
             if (_locals.TryGetValue(node, out var local))
-                codeGen.Emit(OpCodes.Ldloc, local);
+                codeGen.Ldloc(local);
             else
                 throw new XamlLoadException("Attempt to read uninitialized local variable", node);
         }

--- a/src/XamlX/IL/ILEmitHelpers.cs
+++ b/src/XamlX/IL/ILEmitHelpers.cs
@@ -20,8 +20,7 @@ namespace XamlX.IL
             var ftype = field.FieldType.IsEnum ? field.FieldType.GetEnumUnderlyingType() : field.FieldType;
 
             if (ftype.Name == "UInt64" || ftype.Name == "Int64")
-                codeGen.Emit(OpCodes.Ldc_I8,
-                    TypeSystemHelpers.ConvertLiteralToLong(field.GetLiteralValue()));
+                codeGen.Emit(OpCodes.Ldc_I8, TypeSystemHelpers.ConvertLiteralToLong(field.GetLiteralValue()));
             else if (ftype.Name == "Double")
                 codeGen.Emit(OpCodes.Ldc_R8, (double)field.GetLiteralValue());
             else if (ftype.Name == "Single")
@@ -29,14 +28,13 @@ namespace XamlX.IL
             else if (ftype.Name == "String")
                 codeGen.Emit(OpCodes.Ldstr, (string)field.GetLiteralValue());
             else
-                codeGen.Emit(OpCodes.Ldc_I4,
-                    TypeSystemHelpers.ConvertLiteralToInt(field.GetLiteralValue()));
+                codeGen.Ldc_I4(TypeSystemHelpers.ConvertLiteralToInt(field.GetLiteralValue()));
         }
 
         public static void EmitConvert(XamlEmitContextWithLocals<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter ilgen, IXamlLineInfo node, IXamlType what,
             IXamlType to, IXamlLocal local)
         {
-            EmitConvert(context, node, what, to, lda => ilgen.Emit(lda ? OpCodes.Ldloca : OpCodes.Ldloc, local));
+            EmitConvert(context, node, what, to, lda => lda ? ilgen.Ldloca(local) : ilgen.Ldloc(local));
         }
 
         public static void EmitConvert(XamlEmitContextWithLocals<IXamlILEmitter, XamlILNodeEmitResult> context, IXamlILEmitter ilgen, IXamlLineInfo node,

--- a/src/XamlX/IL/IXamlILEmitter.cs
+++ b/src/XamlX/IL/IXamlILEmitter.cs
@@ -21,6 +21,8 @@ namespace XamlX.IL
         IXamlILEmitter Emit(OpCode code, string arg);
         IXamlILEmitter Emit(OpCode code, int arg);
         IXamlILEmitter Emit(OpCode code, long arg);
+        IXamlILEmitter Emit(OpCode code, sbyte arg);
+        IXamlILEmitter Emit(OpCode code, byte arg);
         IXamlILEmitter Emit(OpCode code, IXamlType type);
         IXamlILEmitter Emit(OpCode code, float arg);
         IXamlILEmitter Emit(OpCode code, double arg);

--- a/src/XamlX/IL/IXamlILLocal.cs
+++ b/src/XamlX/IL/IXamlILLocal.cs
@@ -1,0 +1,12 @@
+﻿using XamlX.TypeSystem;
+
+namespace XamlX.IL
+{
+#if !XAMLX_INTERNAL
+    public
+#endif
+    interface IXamlILLocal : IXamlLocal
+    {
+        int Index { get; }
+    }
+}

--- a/src/XamlX/IL/RecordingIlEmitter.cs
+++ b/src/XamlX/IL/RecordingIlEmitter.cs
@@ -98,6 +98,20 @@ namespace XamlX.IL
             _inner.Emit(code, arg);
             return this;
         }
+        
+        public IXamlILEmitter Emit(OpCode code, sbyte arg)
+        {
+            Record(code, arg);
+            _inner.Emit(code, arg);
+            return this;
+        }
+        
+        public IXamlILEmitter Emit(OpCode code, byte arg)
+        {
+            Record(code, arg);
+            _inner.Emit(code, arg);
+            return this;
+        }
 
         public IXamlILEmitter Emit(OpCode code, IXamlType type)
         {

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -472,6 +472,18 @@ namespace XamlX.IL
                 return this;
             }
             
+            public IXamlILEmitter Emit(OpCode code, sbyte arg)
+            {
+                _ilg.Emit(code, arg);
+                return this;
+            }
+            
+            public IXamlILEmitter Emit(OpCode code, byte arg)
+            {
+                _ilg.Emit(code, arg);
+                return this;
+            }
+            
             public IXamlILEmitter Emit(OpCode code, float arg)
             {
                 _ilg.Emit(code, arg);
@@ -542,9 +554,11 @@ namespace XamlX.IL
                 }
             }
             
-            class SreLocal : IXamlLocal
+            class SreLocal : IXamlILLocal
             {
                 public LocalBuilder Local { get; }
+
+                public int Index => Local.LocalIndex;
 
                 public SreLocal(LocalBuilder local)
                 {

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -321,7 +321,11 @@ namespace XamlX.IL
                 _system = system;
             }
 
-            public bool Equals(IXamlMethod other) => ((SreMethod) other)?.Method.Equals(Method) == true;
+            public bool Equals(IXamlMethod other) 
+                => other is SreMethod typedOther && Method == typedOther.Method;
+
+            public override int GetHashCode() 
+                => Method.GetHashCode();
 
             public IXamlMethod MakeGenericMethod(IReadOnlyList<IXamlType> typeArguments)
             {
@@ -411,7 +415,8 @@ namespace XamlX.IL
             }
 
             public override string ToString() => Field.DeclaringType?.FullName + " " + Field.Name;
-            public bool Equals(IXamlField other) => ((SreField) other)?.Field.Equals(Field) == true;
+            public bool Equals(IXamlField other) => other is SreField typedOther && typedOther.Field == Field;
+            public override int GetHashCode() => Field.GetHashCode();
         }
 
         public IXamlILEmitter CreateCodeGen(MethodBuilder mb)

--- a/src/XamlX/IL/XamlILEmitterExtensions.cs
+++ b/src/XamlX/IL/XamlILEmitterExtensions.cs
@@ -36,7 +36,15 @@ namespace XamlX.IL
         }
 
         public static IXamlILEmitter Ldarg(this IXamlILEmitter emitter, int arg)
-    => emitter.Emit(OpCodes.Ldarg, arg);
+            => arg switch
+            {
+                0 => emitter.Emit(OpCodes.Ldarg_0),
+                1 => emitter.Emit(OpCodes.Ldarg_1),
+                2 => emitter.Emit(OpCodes.Ldarg_2),
+                3 => emitter.Emit(OpCodes.Ldarg_3),
+                >= 4 and <= byte.MaxValue => emitter.Emit(OpCodes.Ldarg_S, (byte) arg),
+                _ => emitter.Emit(OpCodes.Ldarg, arg)
+            };
 
         public static IXamlILEmitter Ldarg_0(this IXamlILEmitter emitter)
             => emitter.Emit(OpCodes.Ldarg_0);
@@ -57,13 +65,32 @@ namespace XamlX.IL
             => emitter.Emit(OpCodes.Stsfld, field);
 
         public static IXamlILEmitter Ldloc(this IXamlILEmitter emitter, IXamlLocal local)
-            => emitter.Emit(OpCodes.Ldloc, local);
+            => (local as IXamlILLocal)?.Index switch
+            {
+                0 => emitter.Emit(OpCodes.Ldloc_0),
+                1 => emitter.Emit(OpCodes.Ldloc_1),
+                2 => emitter.Emit(OpCodes.Ldloc_2),
+                3 => emitter.Emit(OpCodes.Ldloc_3),
+                >= 4 and <= byte.MaxValue => emitter.Emit(OpCodes.Ldloc_S, local),
+                _ => emitter.Emit(OpCodes.Ldloc, local)
+            };
 
         public static IXamlILEmitter Ldloca(this IXamlILEmitter emitter, IXamlLocal local)
-            => emitter.Emit(OpCodes.Ldloca, local);
+        {
+            var index = (local as IXamlILLocal)?.Index;
+            return emitter.Emit(index is >= 0 and <= byte.MaxValue ? OpCodes.Ldloca_S : OpCodes.Ldloca, local);
+        }
 
-        public static IXamlILEmitter Stloc(this IXamlILEmitter emitter, IXamlLocal local)
-            => emitter.Emit(OpCodes.Stloc, local);
+        public static IXamlILEmitter Stloc(this IXamlILEmitter emitter, IXamlLocal local) 
+            => (local as IXamlILLocal)?.Index switch
+            {
+                0 => emitter.Emit(OpCodes.Stloc_0),
+                1 => emitter.Emit(OpCodes.Stloc_1),
+                2 => emitter.Emit(OpCodes.Stloc_2),
+                3 => emitter.Emit(OpCodes.Stloc_3),
+                >= 4 and <= byte.MaxValue => emitter.Emit(OpCodes.Stloc_S, local),
+                _ => emitter.Emit(OpCodes.Stloc, local)
+            };
 
         public static IXamlILEmitter Ldnull(this IXamlILEmitter emitter) => emitter.Emit(OpCodes.Ldnull);
 
@@ -74,11 +101,21 @@ namespace XamlX.IL
             => emitter.Emit(OpCodes.Throw);
 
         public static IXamlILEmitter Ldc_I4(this IXamlILEmitter emitter, int arg)
-            => arg == 0
-                ? emitter.Emit(OpCodes.Ldc_I4_0)
-                : arg == 1
-                    ? emitter.Emit(OpCodes.Ldc_I4_1)
-                    : emitter.Emit(OpCodes.Ldc_I4, arg);
+            => arg switch
+            {
+                0 => emitter.Emit(OpCodes.Ldc_I4_0),
+                1 => emitter.Emit(OpCodes.Ldc_I4_1),
+                2 => emitter.Emit(OpCodes.Ldc_I4_2),
+                3 => emitter.Emit(OpCodes.Ldc_I4_3),
+                4 => emitter.Emit(OpCodes.Ldc_I4_4),
+                5 => emitter.Emit(OpCodes.Ldc_I4_5),
+                6 => emitter.Emit(OpCodes.Ldc_I4_6),
+                7 => emitter.Emit(OpCodes.Ldc_I4_7),
+                8 => emitter.Emit(OpCodes.Ldc_I4_8),
+                -1 => emitter.Emit(OpCodes.Ldc_I4_M1),
+                >= sbyte.MinValue and <= sbyte.MaxValue => emitter.Emit(OpCodes.Ldc_I4_S, (sbyte) arg),
+                _ => emitter.Emit(OpCodes.Ldc_I4, arg)
+            };
 
         public static IXamlILEmitter Ldc_R8(this IXamlILEmitter emitter, double arg)
             => emitter.Emit(OpCodes.Ldc_R8, arg);

--- a/src/XamlX/IL/XamlIlCompiler.cs
+++ b/src/XamlX/IL/XamlIlCompiler.cs
@@ -68,7 +68,7 @@ namespace XamlX.IL
                 codeGen
                     .Emit(OpCodes.Ldarg_0);
                 context.Factory(codeGen);
-                codeGen.Emit(OpCodes.Stloc, contextLocal);
+                codeGen.Stloc(contextLocal);
             }
 
             var emitContext = new ILEmitContext(codeGen, _configuration,
@@ -91,12 +91,12 @@ namespace XamlX.IL
             var rv = codeGen.DefineLocal(rootInstance.Type.GetClrType());
             emitContext.Emit(rootInstance, codeGen, rootInstance.Type.GetClrType());
             codeGen
-                .Emit(OpCodes.Stloc, rv)
-                .Emit(OpCodes.Ldarg_0)
-                .Emit(OpCodes.Ldloc, rv)
+                .Stloc(rv)
+                .Ldarg_0()
+                .Ldloc(rv)
                 .EmitCall(compiledPopulate)
-                .Emit(OpCodes.Ldloc, rv)
-                .Emit(OpCodes.Ret);
+                .Ldloc(rv)
+                .Ret();
         }
 
         /// <summary>
@@ -112,10 +112,10 @@ namespace XamlX.IL
             var emitContext = InitCodeGen(fileSource, createSubType, createDelegateType, codeGen, context, true);
 
             codeGen
-                .Emit(OpCodes.Ldloc, emitContext.ContextLocal)
+                .Ldloc(emitContext.ContextLocal)
                 .Emit(OpCodes.Ldarg_1)
                 .Emit(OpCodes.Stfld, context.RootObjectField)
-                .Emit(OpCodes.Ldloc, emitContext.ContextLocal)
+                .Ldloc(emitContext.ContextLocal)
                 .Emit(OpCodes.Ldarg_1)
                 .Emit(OpCodes.Stfld, context.IntermediateRootObjectField)
                 .Emit(OpCodes.Ldarg_1);

--- a/src/XamlX/IL/XamlIlCompiler.cs
+++ b/src/XamlX/IL/XamlIlCompiler.cs
@@ -97,6 +97,8 @@ namespace XamlX.IL
                 .EmitCall(compiledPopulate)
                 .Ldloc(rv)
                 .Ret();
+
+            emitContext.ExecuteAfterEmitCallbacks();
         }
 
         /// <summary>
@@ -121,6 +123,8 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ldarg_1);
             emitContext.Emit(manipulation, codeGen, null);
             codeGen.Emit(OpCodes.Ret);
+
+            emitContext.ExecuteAfterEmitCallbacks();
         }
 
         protected override XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult> CreateRuntimeContext(

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -211,6 +211,7 @@ namespace XamlX.Transform
         public IXamlType IListOfT { get; }
         public IXamlType Object { get; }
         public IXamlType String { get; }
+        public IXamlType Int32 { get; }
         public IXamlType Void { get; }
         public IXamlType Boolean { get; }
         public IXamlType Double { get; }
@@ -223,6 +224,7 @@ namespace XamlX.Transform
         {
             Void = typeSystem.GetType("System.Void");
             String = typeSystem.GetType("System.String");
+            Int32 = typeSystem.GetType("System.Int32");
             Object = typeSystem.GetType("System.Object");
             Boolean = typeSystem.GetType("System.Boolean");
             Double = typeSystem.GetType("System.Double");

--- a/src/XamlX/Transform/Transformers/ResolvePropertyValueAddersTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ResolvePropertyValueAddersTransformer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using XamlX.Ast;
@@ -23,7 +24,7 @@ namespace XamlX.Transform.Transformers
             return node;
         }
         
-        class AdderSetter : IXamlPropertySetter, IXamlEmitablePropertySetter<IXamlILEmitter>
+        class AdderSetter : IXamlPropertySetter, IXamlEmitablePropertySetter<IXamlILEmitter>, IEquatable<AdderSetter>
         {
             private readonly IXamlMethod _getter;
             private readonly IXamlMethod _adder;
@@ -34,16 +35,22 @@ namespace XamlX.Transform.Transformers
                 _adder = adder;
                 TargetType = getter.DeclaringType;
                 Parameters = adder.ParametersWithThis().Skip(1).ToList();
+
+                bool allowNull = Parameters.Last().AcceptsNull();
+                BinderParameters = new PropertySetterBinderParameters
+                {
+                    AllowMultiple = true,
+                    AllowXNull = allowNull,
+                    AllowRuntimeNull = allowNull
+                };
             }
 
             public IXamlType TargetType { get; }
 
-            public PropertySetterBinderParameters BinderParameters { get; } = new PropertySetterBinderParameters
-            {
-                AllowMultiple = true
-            };
+            public PropertySetterBinderParameters BinderParameters { get; }
             
             public IReadOnlyList<IXamlType> Parameters { get; }
+            
             public void Emit(IXamlILEmitter emitter)
             {
                 var locals = new Stack<XamlLocalsPool.PooledLocal>();
@@ -61,6 +68,22 @@ namespace XamlX.Transform.Transformers
                         emitter.Ldloc(loc.Local);
                 emitter.EmitCall(_adder, true);
             }
+
+            public bool Equals(AdderSetter other)
+            {
+                if (ReferenceEquals(null, other))
+                    return false;
+                if (ReferenceEquals(this, other))
+                    return true;
+
+                return _getter.Equals(other._getter) && _adder.Equals(other._adder);
+            }
+
+            public override bool Equals(object obj) 
+                => Equals(obj as AdderSetter);
+
+            public override int GetHashCode() 
+                => (_getter.GetHashCode() * 397) ^ _adder.GetHashCode();
         }
     }
 }

--- a/src/XamlX/Transform/Transformers/ResolvePropertyValueAddersTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ResolvePropertyValueAddersTransformer.cs
@@ -24,7 +24,7 @@ namespace XamlX.Transform.Transformers
             return node;
         }
         
-        class AdderSetter : IXamlPropertySetter, IXamlEmitablePropertySetter<IXamlILEmitter>, IEquatable<AdderSetter>
+        class AdderSetter : IXamlILOptimizedEmitablePropertySetter, IEquatable<AdderSetter>
         {
             private readonly IXamlMethod _getter;
             private readonly IXamlMethod _adder;
@@ -66,6 +66,19 @@ namespace XamlX.Transform.Transformers
                 while (locals.Count>0)
                     using (var loc = locals.Pop())
                         emitter.Ldloc(loc.Local);
+                emitter.EmitCall(_adder, true);
+            }
+
+            public void EmitWithArguments(
+                XamlEmitContextWithLocals<IXamlILEmitter, XamlILNodeEmitResult> context,
+                IXamlILEmitter emitter,
+                IReadOnlyList<IXamlAstValueNode> arguments)
+            {
+                emitter.EmitCall(_getter);
+
+                for (var i = 0; i < arguments.Count; ++i)
+                    context.Emit(arguments[i], emitter, Parameters[i]);
+
                 emitter.EmitCall(_adder, true);
             }
 

--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -57,11 +57,6 @@ namespace XamlX.Transform
                     .OrderByDescending(x => x.ThisOrFirstParameter().Equals(actualType))
                     .ThenBy(x => x.ThisOrFirstParameter().IsInterface)
                     .ToList();
-                
-                // Add casts
-                for (var c = 0; c < rv.Count; c++)
-                    if (!rv[c].ThisOrFirstParameter().Equals(type))
-                        rv[c] = new XamlMethodWithCasts(rv[c], new[] {type}.Concat(rv[c].Parameters));
 
                 if(context.Configuration.TypeMappings.IAddChildOfT != null)
                 {

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -449,6 +449,9 @@ namespace XamlX.TypeSystem
             return null;
         }
 
+        public static bool AcceptsNull(this IXamlType type) 
+            => !type.IsValueType || type.IsNullable();
+
         public static bool IsNullable(this IXamlType type)
         {
             var def = type.GenericTypeDefinition;

--- a/tests/XamlParserTests/DynamicSettersTests.cs
+++ b/tests/XamlParserTests/DynamicSettersTests.cs
@@ -1,0 +1,317 @@
+﻿using System;
+using Xunit;
+
+namespace XamlParserTests
+{
+    public class DynamicSettersClass<T1, T2>
+    {
+        internal bool AddT1Called;
+        internal T1 T1Result;
+
+        internal bool AddT2Called;
+        internal T2 T2Result;
+
+        public void Add(T1 value)
+        {
+            AddT1Called = true;
+            T1Result = value;
+        }
+
+        public void Add(T2 value)
+        {
+            AddT2Called = true;
+            T2Result = value;
+        }
+    }
+
+    public class DynamicProvider
+    {
+        public enum ProvidedValueType { Null, String, Uri, Int32, TimeSpan, DateTime }
+
+        public ProvidedValueType ProvidedValue { get; set; }
+
+        public object ProvideValue()
+        {
+            return ProvidedValue switch
+            {
+                ProvidedValueType.Null => null,
+                ProvidedValueType.String => "foo",
+                ProvidedValueType.Uri => new Uri("https://avaloniaui.net/"),
+                ProvidedValueType.Int32 => 1234,
+                ProvidedValueType.TimeSpan => new TimeSpan(12, 34, 56, 789),
+                ProvidedValueType.DateTime => DateTime.Now,
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+    }
+
+    public class DynamicSettersTests : CompilerTestBase
+    {
+        [Fact]
+        public void Dynamic_Setter_With_Reference_Types_And_Null_Argument_Should_Match_Any()
+        {
+            var result = (DynamicSettersClass<string, Uri>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:String,sys:Uri' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Null' />
+</DynamicSettersClass>
+");
+            // we can't be sure that AddT1 is always called because it's first: metadata order isn't guaranteed
+            Assert.True(result.AddT1Called ^ result.AddT2Called);
+            Assert.Null(result.T1Result);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Reference_Types_And_Typed_Argument_Should_Match_1()
+        {
+            var result = (DynamicSettersClass<string, Uri>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:String,sys:Uri' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='String' />
+</DynamicSettersClass>
+");
+            Assert.True(result.AddT1Called);
+            Assert.Equal("foo", result.T1Result);
+            Assert.False(result.AddT2Called);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Reference_Types_And_Typed_Argument_Should_Match_2()
+        {
+            var result = (DynamicSettersClass<string, Uri>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:String,sys:Uri' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Uri' />
+</DynamicSettersClass>
+");
+            Assert.False(result.AddT1Called);
+            Assert.Null(result.T1Result);
+            Assert.True(result.AddT2Called);
+            Assert.Equal(new Uri("https://avaloniaui.net/"), result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Value_Types_And_Null_Argument_Should_Throw_NullReferenceException()
+        {
+            Assert.Throws<NullReferenceException>(() => CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Int32,sys:TimeSpan' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Null' />
+</DynamicSettersClass>
+"));
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Value_Types_And_Typed_Argument_Should_Match_1()
+        {
+            var result = (DynamicSettersClass<int, TimeSpan>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Int32,sys:TimeSpan' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Int32' />
+</DynamicSettersClass>
+");
+            Assert.True(result.AddT1Called);
+            Assert.Equal(1234, result.T1Result);
+            Assert.False(result.AddT2Called);
+            Assert.Equal(default, result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Value_Types_And_Typed_Argument_Should_Match_2()
+        {
+            var result = (DynamicSettersClass<int, TimeSpan>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Int32,sys:TimeSpan' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='TimeSpan' />
+</DynamicSettersClass>
+");
+            Assert.False(result.AddT1Called);
+            Assert.Equal(default, result.T1Result);
+            Assert.True(result.AddT2Called);
+            Assert.Equal(new TimeSpan(12, 34, 56, 789), result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Nullable_Value_Types_And_Null_Argument_Should_Match_Any()
+        {
+            var result = (DynamicSettersClass<int?, TimeSpan?>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Nullable(sys:Int32),sys:Nullable(sys:TimeSpan)' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Null' />
+</DynamicSettersClass>
+");
+            // we can't be sure that AddT1 is always called because it's first: metadata order isn't guaranteed
+            Assert.True(result.AddT1Called ^ result.AddT2Called);
+            Assert.Null(result.T1Result);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Nullable_Value_Types_And_Typed_Argument_Should_Match_1()
+        {
+            var result = (DynamicSettersClass<int?, TimeSpan?>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Nullable(sys:Int32),sys:Nullable(sys:TimeSpan)' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Int32' />
+</DynamicSettersClass>
+");
+            Assert.True(result.AddT1Called);
+            Assert.Equal(1234, result.T1Result);
+            Assert.False(result.AddT2Called);
+            Assert.Equal(default, result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Nullable_Value_Types_And_Typed_Argument_Should_Match_2()
+        {
+            var result = (DynamicSettersClass<int?, TimeSpan?>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Nullable(sys:Int32),sys:Nullable(sys:TimeSpan)' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='TimeSpan' />
+</DynamicSettersClass>
+");
+            Assert.False(result.AddT1Called);
+            Assert.Equal(default, result.T1Result);
+            Assert.True(result.AddT2Called);
+            Assert.Equal(new TimeSpan(12, 34, 56, 789), result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Value_Type_And_Reference_Type_And_Null_Argument_Should_Match_Reference()
+        {
+            var result = (DynamicSettersClass<int, string>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Int32,sys:String' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Null' />
+</DynamicSettersClass>
+");
+            Assert.False(result.AddT1Called);
+            Assert.Equal(default, result.T1Result);
+            Assert.True(result.AddT2Called);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Value_Type_And_Reference_Type_And_Value_Type_Argument_Should_Match_Value_Type()
+        {
+            var result = (DynamicSettersClass<int, string>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Int32,sys:String' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Int32' />
+</DynamicSettersClass>
+");
+            Assert.True(result.AddT1Called);
+            Assert.Equal(1234, result.T1Result);
+            Assert.False(result.AddT2Called);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Nullable_Value_Type_And_Reference_Type_And_Null_Argument_Should_Match_Any()
+        {
+            var result = (DynamicSettersClass<int?, string>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Nullable(sys:Int32),sys:String' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Null' />
+</DynamicSettersClass>
+");
+            // we can't be sure that AddT1 is always called because it's first: metadata order isn't guaranteed
+            Assert.True(result.AddT1Called ^ result.AddT2Called);
+            Assert.Null(result.T1Result);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Nullable_Value_Type_And_Reference_Type_And_Value_Type_Argument_Should_Match_Nullable_Value_Type()
+        {
+            var result = (DynamicSettersClass<int?, string>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Nullable(sys:Int32),sys:String' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='Int32' />
+</DynamicSettersClass>
+");
+            Assert.True(result.AddT1Called);
+            Assert.Equal(1234, result.T1Result);
+            Assert.False(result.AddT2Called);
+            Assert.Null(result.T2Result);
+        }
+
+        [Fact]
+        public void Dynamic_Setter_With_Nullable_Value_Type_And_Reference_Type_And_Reference_Type_Argument_Should_Match_Reference_Type()
+        {
+            var result = (DynamicSettersClass<int?, string>) CompileAndRun(@"
+<DynamicSettersClass 
+    x:TypeArguments='sys:Nullable(sys:Int32),sys:String' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='String' />
+</DynamicSettersClass>
+");
+            Assert.False(result.AddT1Called);
+            Assert.Equal(default, result.T1Result);
+            Assert.True(result.AddT2Called);
+            Assert.Equal("foo", result.T2Result);
+        }
+
+        [Theory]
+        [InlineData("sys:Int32", "sys:TimeSpan")]
+        [InlineData("sys:String", "sys:Uri")]
+        [InlineData("sys:Nullable(sys:Int32)", "sys:Nullable(sys:TimeSpan)")]
+        [InlineData("sys:Int32", "sys:String")]
+        [InlineData("sys:Nullable(sys:Int32)", "sys:String")]
+        public void Dynamic_Setter_With_Mismatched_Argument_Should_Throw_InvalidCastException(string type1, string type2)
+        {
+            Assert.Throws<InvalidCastException>(() => CompileAndRun($@"
+<DynamicSettersClass 
+    x:TypeArguments='{type1},{type2}' 
+    xmlns='clr-namespace:XamlParserTests'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'>
+  <DynamicProvider ProvidedValue='DateTime' />
+</DynamicSettersClass>
+"));
+        }
+    }
+}

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -21,6 +21,15 @@ namespace XamlParserTests
         public const double DoubleConstant = 3;
     }
 
+    public class IntrinsicsListTestsClass
+    {
+        internal int AddInt32CallCount;
+        internal int AddObjectCallCount;
+
+        public void Add(int value) => ++AddInt32CallCount;
+        public void Add(object value) => ++AddObjectCallCount;
+    }
+
     public enum IntrinsicsTestsEnum : long
     {
         Foo = 100500
@@ -45,6 +54,19 @@ namespace XamlParserTests
 <IntrinsicsTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
     <IntrinsicsTestsClass.IntProperty><x:Null/></IntrinsicsTestsClass.IntProperty>
 </IntrinsicsTestsClass>"));
+        }
+
+        [Fact]
+        public void Null_Extension_Should_Disregard_Value_Type_Overloads()
+        {
+            var res = (IntrinsicsListTestsClass) CompileAndRun($@"
+<IntrinsicsListTestsClass xmlns='test' xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>
+    <x:Null />
+    <x:Null />
+</IntrinsicsListTestsClass>");
+
+            Assert.Equal(0, res.AddInt32CallCount);
+            Assert.Equal(2, res.AddObjectCallCount);
         }
 
         [Theory,

--- a/tests/XamlParserTests/ServiceProviderTests.cs
+++ b/tests/XamlParserTests/ServiceProviderTests.cs
@@ -225,7 +225,7 @@ namespace XamlParserTests
                 Helpers.StructDiff(nsList,
                     new Dictionary<string, IReadOnlyList<XamlXmlNamespaceInfoV1>>
                     {
-                        [""] = new List<XamlXmlNamespaceInfoV1>
+                        [""] = new[]
                         {
                             new XamlXmlNamespaceInfoV1
                             {
@@ -233,7 +233,7 @@ namespace XamlParserTests
                                 ClrAssemblyName = typeof(ServiceProviderTests).Assembly.GetName().Name
                             }
                         },
-                        ["clr1"] = new List<XamlXmlNamespaceInfoV1>
+                        ["clr1"] = new[]
                         {
                             new XamlXmlNamespaceInfoV1
                             {
@@ -241,7 +241,7 @@ namespace XamlParserTests
                                 ClrAssemblyName = "netstandard"
                             }
                         },
-                        ["clr2"] = new List<XamlXmlNamespaceInfoV1>
+                        ["clr2"] = new[]
                         {
                             new XamlXmlNamespaceInfoV1
                             {
@@ -272,21 +272,21 @@ namespace XamlParserTests
                 Helpers.StructDiff(nsList,
                     new Dictionary<string, IReadOnlyList<XamlXmlNamespaceInfoV1>>
                     {
-                        [""] = new List<XamlXmlNamespaceInfoV1>
+                        [""] = new[]
                         {
                             new XamlXmlNamespaceInfoV1
                             {
                                 ClrNamespace = "XamlParserTests"
                             }
                         },
-                        ["clr1"] = new List<XamlXmlNamespaceInfoV1>
+                        ["clr1"] = new[]
                         {
                             new XamlXmlNamespaceInfoV1
                             {
                                 ClrNamespace = "System.Collections.Generic"
                             }
                         },
-                        ["clr2"] = new List<XamlXmlNamespaceInfoV1>
+                        ["clr2"] = new[]
                         {
                             new XamlXmlNamespaceInfoV1
                             {


### PR DESCRIPTION
I was poking around the IL generated from XAML files by Avalonia to understand how the IL compiler works, and noticed some redundant instructions. So here's a pull request trying to optimize those a bit :) The goal is to reduce the final IL size, and if possible improve the JIT compiling times, [which are high](https://github.com/AvaloniaUI/Avalonia/issues/5666#issuecomment-799408016).

## Notes

`Avalonia.Themes.Fluent` was the main target of these optimizations since it has many, relatively heavy, XAML files.

This PR contains several independent commits and I think it's easier to review commit per commit. If needed, I can split it into several PRs. 

`LangVersion` is set to `latest` to use `switch` expressions and improved pattern matching. If that's not acceptable, I can rewrite those with older C# constructs.

Hopefully no breaking changes in public, non-IL specific types (`IXamlPropertySetter`, etc.). However there are new overloads in `IXamlILEmitter`, which is technically breaking, but is very unlikely to be implemented by types other than those already in XamlX.

## Commits

### Fixed x:Null incorrectly being assignable to a value type for Cecil

Not an optimization, but a fix for a bug I stumbled upon later when optimizing the property setters. For Cecil, `x:Null` was always incorrectly assignable to everything, even value types. It now has the same logic as S.R.Emit. A failing test has been added, which now passes.

### Using optimized ldloc/stloc/ldarg/ldc.i4 opcodes when possible

A low hanging fruit: use the short encoding forms of `ldloc`/`stloc`/`ldc.i4` when possible. This reduces most `ldloc`/`stloc` from 5 bytes to 1. SRE already does this automatically internally, but Cecil doesn't.

### Removed unnecessary casts for dynamic property assignments

`PropertyAssignmentEmitter` was adding an unneeded cast right after a value was checked to either be statically assignable by downcast, or after a runtime `isinst` call, which pushes the correct the type on the stack on success.

### Removed unnecessary casts for adders

Casts were present on base interface calls for adders, which was very noticeable for Avalonia's `Style.Resources` which is typed as `IResourceDictionary`, but whose `Add` method is on `IDictionary<TKey,TValue>`. This removes those as they're not necessary. (Even `IAddChild` logic, which is right after, didn't add those casts.)

### NamespaceInfoProvider: generated CreateNamespaceInfo method to avoid duplicate code

This commits generates a simple helper function to reduce highly duplicated code when generating the namespaces alias mappings.

### Cached dynamic property setters

The biggest change in this PR. When `PropertyAssignmentEmitter` has to do runtime dispatch because there are multiple setters that can't be resolved at compile time, it now generates a single reusable method for those setters, per XAML file. For `Avalonia.Themes.Fluent`, all `<SolidColorBrush x:Key="xxx" Color="{StaticResource yyy}" />` in a single file calls an unique method instead of generating the same branches that check if the static resource returned an `UnsetValueType`, `IBinding` or `Color`. The result is 8 different methods in the assembly instead of 183 times the branches.

This commit requires that `IXamlPropertySetter` correctly implements `Equals` and `GetHashCode`. If an implementation doesn't, the generated code is still correc: the generated method simply won't be reused (so no IL size gain). Ideally `IXamlPropertySetter` should inherit from `IEquatable<IXamlPropertySetter>` but that would be a breaking change. If this PR is accepted, I have a follow up one on Avalonia for its custom setter implementations.

`GetHashCode` is implemented on `PropertySetterBinderParameters` despite this class being mutable, but it doesn't matter in practice: binding parameters are never changed once assigned in existing code (and doing so would probably break things).

While writing this, I noticed that `AllowRuntimeNull` wasn't really working. Each generated branch is checking for the value to be of a specific type, so `null` won't ever match even when this property is `true`. This is fixed.

### Property setters can emit their own arguments for better IL generation

`IXamlPropertySetter.Emit` is called with arguments already being on the stack. Most custom setters need to push extra arguments before, and thus resort to `stloc` all existing arguments, push what they need, then `ldloc` the arguments. This is really noticeable on adders. A new `IXamlILOptimizedEmitablePropertySetter` interface has been added that setters can optionally implement, which must emit the arguments itself.

If this PR is accepted, I have a follow up one on Avalonia that implements this interface on the custom setters.

### Lazy NamespaceInfoProvider.XmlNamespaces

This commit doesn't decrease IL size, but avoids the work of creating the XML namespace dictionary on initialization. The `XmlNamespaces` property has a lazy implementation instead, which will be jitted only when needed. 

This also helps to reduce runtime memory allocations a little bit: in Avalonia those namespaces are only used in reflection bindings using either `FindAncestor` or having an attached property in their path.

The lazy initialization is lock free: it's very likely to be used on a single thread, if it isn't the race isn't problematic since the dictionary creation has no side effect, and the returned dictionary is read-only and never mutated.

Additionally, the returned dictionary uses an initial capacity and fixed size arrays, to avoid allocating unused memory.

## Results

### JIT

With `Avalonia.Themes.Fluent` stripped of its fonts (to keep only code), here are the results of this PR on my PC:

|               | Before   | After   | Diff   |
| :------------ | -------: | ------: | -----: |
| File Size     |   833 KB |  574 KB | -31.1% |
| Run (JIT)     |   293 ms |  254 ms | -13.3% |

The *Run (JIT)* column is the time spent in `AvaloniaLoader.Load(this)` in an empty App that has only `<FluentTheme />` in its styles. Average of 10 runs in Release mode, with the .NET 6.0.7 runtime.

Overall, some noticeable improvements in both file size and JIT time spent.

### R2R

Being curious, I also tested ReadyToRun (win-x64):

|               | Before   | After   | Diff   |
| :------------ | -------: | ------: | -----: |
| File Size R2R |  2501 KB | 1939 KB | -22.5% |
| Run (R2R)     |   186 ms |  186 ms |   0.0% |

As expected the PR doesn't improve the run time since the JIT is barely involved, but the final assembly still has a nice size reduction.
