### PR TITLE
Ignore modopt/modreq on Cecil types to match SRE

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,11 @@
 <Project>
+
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
+
 </Project>

--- a/src/XamlX.IL.Cecil/CecilTypeCache.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeCache.cs
@@ -30,6 +30,11 @@ namespace XamlX.TypeSystem
             {
                 if (reference.GetType() == typeof(TypeReference))
                     reference = reference.Resolve();
+                else if (reference is RequiredModifierType modReqType)
+                    reference = modReqType.ElementType;
+                else if (reference is OptionalModifierType modOptType)
+                    reference = modOptType.ElementType;
+
                 var definition = reference.Resolve();
                 var asm = TypeSystem.FindAsm(definition.Module.Assembly);
                 if (!_definitions.TryGetValue(definition, out var dentry))

--- a/tests/XamlParserTests/SpecialPropertiesTests.cs
+++ b/tests/XamlParserTests/SpecialPropertiesTests.cs
@@ -1,0 +1,29 @@
+﻿using Xunit;
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit
+    {
+    }
+}
+
+namespace XamlParserTests
+{
+    public class InitPropertiesTestClass
+    {
+        public string Prop1 { get; init; }
+        public int Prop2 { get; init; }
+    }
+
+    public class SpecialPropertiesTests : CompilerTestBase
+    {
+        [Fact]
+        public void Init_Properties_Should_Be_Set()
+        {
+            var result = (InitPropertiesTestClass) CompileAndRun(
+                "<InitPropertiesTestClass xmlns='clr-namespace:XamlParserTests' Prop1='foo' Prop2='42' />");
+            Assert.Equal("foo", result.Prop1);
+            Assert.Equal(42, result.Prop2);
+        }
+    }
+}


### PR DESCRIPTION
Setting `init` properties now work instead of the runtime detecting an invalid program.

The implementation simply ignores `modreq`/`modopt` when present, which matches System.Reflection.Emit (modifiers aren't different types for SRE, but are for Cecil).

Related issue: https://github.com/AvaloniaUI/Avalonia/issues/8573