### PR TITLE
Implement IEnumerator interface explicitly to satisfy dotnet linker

### DIFF
--- a/src/XamlX/IL/RuntimeContext.cs
+++ b/src/XamlX/IL/RuntimeContext.cs
@@ -558,14 +558,16 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ldfld, current)
                 .Emit(OpCodes.Ret);
 
-            enumeratorBuilder.DefineMethod(typeSystem.FindType("System.Void"), new IXamlType[0], "Reset", true, false,
-                    true).Generator
+            enumeratorBuilder.DefineMethod(typeSystem.FindType("System.Void"), new IXamlType[0],
+                    enumeratorObjectType.FullName+".Reset", false, false,
+                    true, enumeratorObjectType.FindMethod(m => m.Name == "Reset")).Generator
                 .Emit(OpCodes.Newobj,
                     typeSystem.FindType("System.NotSupportedException").FindConstructor(new List<IXamlType>()))
                 .Emit(OpCodes.Throw);
-            
+
             var disposeGen = enumeratorBuilder.DefineMethod(typeSystem.FindType("System.Void"), new IXamlType[0], 
-                "Dispose", true, false, true ).Generator;
+                "System.IDisposable.Dispose", false, false, true,
+                typeSystem.GetType("System.IDisposable").FindMethod(m => m.Name == "Dispose")).Generator;
             var disposeRet = disposeGen.DefineLabel();
             disposeGen
                 .Emit(OpCodes.Ldarg_0)
@@ -579,8 +581,9 @@ namespace XamlX.IL
 
             var boolType = typeSystem.GetType("System.Boolean");
             var moveNext = enumeratorBuilder.DefineMethod(boolType, new IXamlType[0],
-                "MoveNext", true,
-                false, true).Generator;
+                enumeratorObjectType.FullName+".MoveNext", false,
+                false, true,
+                enumeratorObjectType.FindMethod(m => m.Name == "MoveNext")).Generator;
 
             
             const int stateInit = 0;


### PR DESCRIPTION
See this unusual stack trace for more context: https://github.com/AvaloniaUI/Avalonia/issues/9127#issuecomment-1327976983

For some unknown reason that would be unreasonably complicated to find out why, dotnet/linker removes IEnumerator interface method implementations from the Enumerator class which we generate. Might be something related to their issues with cecil https://github.com/dotnet/linker/issues/1187 

NativeAOT linked works just fine with implicit methods.
But for mono/linker changing methods to explicitly implement interface helps here.
Other possible reasons: linker doesn't have enough information, because we use this enumerator from "object GetService(Type)" method, or we simply have a mistake in IL generation somewhere (or Cecil has). Like, our methods unnecessarily marked as "virtual" by default.