### PR TITLE
Do not require matching ctor, if top level element

### DIFF
--- a/tests/CecilTests/CompilerTestBase.cs
+++ b/tests/CecilTests/CompilerTestBase.cs
@@ -32,7 +32,7 @@ namespace XamlParserTests
         
         
         protected (Func<IServiceProvider, object> create, Action<IServiceProvider, object> populate) Compile(
-            string xaml)
+            string xaml, bool generateBuildMethod = true)
         {
             var ts = (CecilTypeSystem) (_typeSystem);
             var asm = ts.CreateAndRegisterAssembly("TestAsm", new Version(1, 0),
@@ -51,7 +51,7 @@ namespace XamlParserTests
 
 
             var tb = ts.CreateTypeBuilder(def);
-            Compile(tb, contextTypeDef, xaml);
+            Compile(tb, contextTypeDef, xaml, generateBuildMethod);
             
             var ms = new MemoryStream();
             asm.Write(ms);

--- a/tests/XamlParserTests/BasicCompilerTests.cs
+++ b/tests/XamlParserTests/BasicCompilerTests.cs
@@ -56,6 +56,19 @@ namespace XamlParserTests
         public string Prop { get; set; }
     }
     
+    public class ObjectWithPrivateCtor
+    {
+        private ObjectWithPrivateCtor(string param)
+        {
+            Arg = param;
+        }
+
+        public static ObjectWithPrivateCtor Factory(string param) => new(param);
+        
+        public string Arg { get; set; }
+        public string Prop { get; set; }
+    }
+    
     public class BasicCompilerTests : CompilerTestBase
     {
         [Theory,
@@ -108,7 +121,7 @@ namespace XamlParserTests
         }
         
         [Fact]
-        public void Compiler_Should_Populate_Xaml_Without_ObjectWithoutMatchingCtor()
+        public void Compiler_Should_Populate_Xaml_Without_MatchingCtor()
         {
             var comp = Compile(@"
 <ObjectWithoutMatchingCtor xmlns='test' Prop='321' />", generateBuildMethod: false);
@@ -121,10 +134,30 @@ namespace XamlParserTests
         }
 
         [Fact]
-        public void Compiler_Should_Fail_To_Build_Xaml_Without_ObjectWithoutMatchingCtor()
+        public void Compiler_Should_Fail_To_Build_Xaml_Without_MatchingCtor()
         {
             Assert.Throws<InvalidOperationException>(() => Compile(@"
 <ObjectWithoutMatchingCtor xmlns='test' Prop='321' />"));
+        }
+        
+        [Fact]
+        public void Compiler_Should_Populate_Xaml_Without_Public_Ctor()
+        {
+            var comp = Compile(@"
+<ObjectWithPrivateCtor xmlns='test' Prop='321' />", generateBuildMethod: false);
+
+            var res = ObjectWithPrivateCtor.Factory("123");
+            comp.populate(null, res);
+            
+            Assert.Equal("123", res.Arg);
+            Assert.Equal("321", res.Prop);
+        }
+
+        [Fact]
+        public void Compiler_Should_Fail_To_Build_Xaml_Without_Public_Ctor()
+        {
+            Assert.Throws<InvalidOperationException>(() => Compile(@"
+<ObjectWithPrivateCtor xmlns='test' Prop='321' />"));
         }
     }
 }

--- a/tests/XamlParserTests/BasicCompilerTests.cs
+++ b/tests/XamlParserTests/BasicCompilerTests.cs
@@ -45,6 +45,17 @@ namespace XamlParserTests
         }
     }
 
+    public class ObjectWithoutMatchingCtor
+    {
+        public ObjectWithoutMatchingCtor(string param)
+        {
+            Arg = param;
+        }
+        
+        public string Arg { get; set; }
+        public string Prop { get; set; }
+    }
+    
     public class BasicCompilerTests : CompilerTestBase
     {
         [Theory,
@@ -94,6 +105,26 @@ namespace XamlParserTests
             Assert.Null(res.Child);
 
             Assert.Equal("123", res.Text);
+        }
+        
+        [Fact]
+        public void Compiler_Should_Populate_Xaml_Without_ObjectWithoutMatchingCtor()
+        {
+            var comp = Compile(@"
+<ObjectWithoutMatchingCtor xmlns='test' Prop='321' />", generateBuildMethod: false);
+
+            var res = new ObjectWithoutMatchingCtor("123");
+            comp.populate(null, res);
+            
+            Assert.Equal("123", res.Arg);
+            Assert.Equal("321", res.Prop);
+        }
+
+        [Fact]
+        public void Compiler_Should_Fail_To_Build_Xaml_Without_ObjectWithoutMatchingCtor()
+        {
+            Assert.Throws<InvalidOperationException>(() => Compile(@"
+<ObjectWithoutMatchingCtor xmlns='test' Prop='321' />"));
         }
     }
 }


### PR DESCRIPTION
Makes it easier to live with DI and injecting into the view/windows ctors.