### PR TITLE
Don't allow adding to lists from attributes.

### DIFF
--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -159,6 +159,7 @@ namespace XamlX.Ast
         public bool AllowMultiple { get; set; }
         public bool AllowXNull { get; set; } = true;
         public bool AllowRuntimeNull { get; set; } = true;
+        public bool AllowAttributeSyntax { get; set; } = true;
 
         public bool Equals(PropertySetterBinderParameters other)
         {

--- a/src/XamlX/Ast/Xaml.cs
+++ b/src/XamlX/Ast/Xaml.cs
@@ -35,19 +35,22 @@ namespace XamlX.Ast
     {
         public IXamlAstPropertyReference Property { get; set; }
         public List<IXamlAstValueNode> Values { get; set; }
+        public bool IsAttributeSyntax { get; }
 
         public XamlAstXamlPropertyValueNode(IXamlLineInfo lineInfo,
-            IXamlAstPropertyReference property, IXamlAstValueNode value) : base(lineInfo)
+            IXamlAstPropertyReference property, IXamlAstValueNode value, bool isAttributeSyntax) : base(lineInfo)
         {
             Property = property;
             Values = new List<IXamlAstValueNode> {value};
+            IsAttributeSyntax = isAttributeSyntax;
         }
         
         public XamlAstXamlPropertyValueNode(IXamlLineInfo lineInfo,
-            IXamlAstPropertyReference property, IEnumerable<IXamlAstValueNode> values) : base(lineInfo)
+            IXamlAstPropertyReference property, IEnumerable<IXamlAstValueNode> values, bool isAttributeSyntax) : base(lineInfo)
         {
             Property = property;
             Values = values.ToList();
+            IsAttributeSyntax = isAttributeSyntax;
         }
 
         public override void VisitChildren(Visitor visitor)

--- a/src/XamlX/Parsers/SystemXamlMarkupExtensionParser/SystemXamlMarkupExtensionParser.cs
+++ b/src/XamlX/Parsers/SystemXamlMarkupExtensionParser/SystemXamlMarkupExtensionParser.cs
@@ -44,7 +44,7 @@ namespace XamlX.Parsers.SystemXamlMarkupExtensionParser
                         if (scanner.Token != MeTokenType.EqualSign)
                             throw new MeScannerParseException("Unexpected token " + scanner.Token);
                         var propValue = Read();
-                        rv.Children.Add(new XamlAstXamlPropertyValueNode(li, prop, propValue));
+                        rv.Children.Add(new XamlAstXamlPropertyValueNode(li, prop, propValue, true));
                     }
                     else if (scanner.Token == MeTokenType.String || scanner.Token == MeTokenType.QuotedMarkupExtension
                                                                  || scanner.Token == MeTokenType.Open)

--- a/src/XamlX/Parsers/XDocumentXamlParser.cs
+++ b/src/XamlX/Parsers/XDocumentXamlParser.cs
@@ -240,7 +240,7 @@ namespace XamlX.Parsers
 
                         i.Children.Add(new XamlAstXamlPropertyValueNode(el.AsLi(),
                             new XamlAstNamePropertyReference(el.AsLi(), ptype, pname, type),
-                            ParseTextValueOrMarkupExtension(attr.Value, el, attr.AsLi())));
+                            ParseTextValueOrMarkupExtension(attr.Value, el, attr.AsLi()), true));
                     }
                 }
 
@@ -258,7 +258,8 @@ namespace XamlX.Parsers
                                 new XamlAstXmlTypeReference(el.AsLi(), elementNode.Name.NamespaceName,
                                     pair[0]), pair[1], type
                             ),
-                            ParseValueNodeChildren(elementNode, spaceMode)
+                            ParseValueNodeChildren(elementNode, spaceMode),
+                            false
                         ));
                     }
                     else

--- a/src/XamlX/Parsers/XamlMarkupExtensionParser.cs
+++ b/src/XamlX/Parsers/XamlMarkupExtensionParser.cs
@@ -52,7 +52,7 @@ namespace XamlX.Parsers
                     rv.Arguments.Add(Convert(pa));
                 foreach (var arg in n.NamedArguments)
                     rv.Children.Add(new XamlAstXamlPropertyValueNode(info,
-                        new XamlAstNamePropertyReference(info, rv.Type, arg.name, rv.Type), Convert(arg.value)));
+                        new XamlAstNamePropertyReference(info, rv.Type, arg.name, rv.Type), Convert(arg.value), true));
 
                 return rv;
             }

--- a/src/XamlX/Transform/Transformers/ConvertPropertyValuesToAssignmentsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ConvertPropertyValuesToAssignmentsTransformer.cs
@@ -78,6 +78,9 @@ namespace XamlX.Transform.Transformers
                         {
                             bool CanAssign(IXamlAstValueNode value, IXamlType type)
                             {
+                                if (!setter.BinderParameters.AllowAttributeSyntax && valueNode.IsAttributeSyntax)
+                                    return false;
+
                                 // Don't allow x:Null
                                 if (!setter.BinderParameters.AllowXNull
                                     && XamlPseudoType.Null.Equals(value.Type.GetClrType()))

--- a/src/XamlX/Transform/Transformers/ResolveContentPropertyTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ResolveContentPropertyTransformer.cs
@@ -33,7 +33,7 @@ namespace XamlX.Transform.Transformers
                             if (contentProperty != null)
                                 propertyNode = new XamlAstXamlPropertyValueNode(ni,
                                     new XamlAstClrProperty(ni, contentProperty, context.Configuration),
-                                    Array.Empty<IXamlAstValueNode>());
+                                    Array.Empty<IXamlAstValueNode>(), false);
                             else
                             {
                                 var adders = XamlTransformHelpers.FindPossibleAdders(context, ni.Type.GetClrType());
@@ -57,7 +57,8 @@ namespace XamlX.Transform.Transformers
                                         {
                                             BinderParameters = {AllowMultiple = true}
                                         })),
-                                    Array.Empty<IXamlAstValueNode>());
+                                    Array.Empty<IXamlAstValueNode>(),
+                                    false);
                             }
                         }
                         // We are going in reverse order, so insert at the beginning

--- a/src/XamlX/Transform/Transformers/ResolvePropertyValueAddersTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ResolvePropertyValueAddersTransformer.cs
@@ -41,7 +41,8 @@ namespace XamlX.Transform.Transformers
                 {
                     AllowMultiple = true,
                     AllowXNull = allowNull,
-                    AllowRuntimeNull = allowNull
+                    AllowRuntimeNull = allowNull,
+                    AllowAttributeSyntax = false,
                 };
             }
 

--- a/tests/XamlParserTests/ParserTests.cs
+++ b/tests/XamlParserTests/ParserTests.cs
@@ -87,34 +87,34 @@ namespace XamlParserTests
                                         {
                                             new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                                     extensionType, "Prop", extensionType),
-                                                new XamlAstTextNode(ni, "test", true)),
+                                                new XamlAstTextNode(ni, "test", true), true),
                                             new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                                     extensionType, "Prop2", extensionType),
-                                                new XamlAstTextNode(ni, "test2", true)),
+                                                new XamlAstTextNode(ni, "test2", true), true),
                                             new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                                     extensionType, "Prop3", extensionType),
-                                                new XamlAstObjectNode(ni, extensionType)),
+                                                new XamlAstObjectNode(ni, extensionType), true),
                                             new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                                     extensionType, "Prop4", extensionType),
-                                                new XamlAstTextNode(ni, "test3", true)),
+                                                new XamlAstTextNode(ni, "test3", true), true),
                                         }
-                                    }),                             
+                                    }, true),                             
                                 //Other.Prop='{}Not extension'
                                 new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                         new XamlAstXmlTypeReference(ni, "rootns", "Other"), "Prop", childType),
-                                    new XamlAstTextNode(ni, "Not extension", true)),
+                                    new XamlAstTextNode(ni, "Not extension", true), true),
                                 //  Prop1='123' 
                                 new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                         childType, "Prop1", childType),
-                                    new XamlAstTextNode(ni, "123", true)),
+                                    new XamlAstTextNode(ni, "123", true), true),
                                 // Root.AttachedProp='AttachedValue'
                                 new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                         rootType, "AttachedProp", childType),
-                                    new XamlAstTextNode(ni, "AttachedValue", true)),
+                                    new XamlAstTextNode(ni, "AttachedValue", true), true),
                                 //t:Namespaced.AttachedProp='AttachedValue'
                                 new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                         namespacedType, "AttachedProp", childType),
-                                    new XamlAstTextNode(ni, "AttachedValue", true)),
+                                    new XamlAstTextNode(ni, "AttachedValue", true), true),
                                 //d:Directive='DirectiveValue'>
                                 new XamlAstXmlDirective(ni, "directive", "Directive", new[]
                                 {
@@ -139,11 +139,11 @@ namespace XamlParserTests
                                     {
                                         new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                                 nsSubChildType, "Prop", nsSubChildType),
-                                            new XamlAstTextNode(ni, "321", true)),
+                                            new XamlAstTextNode(ni, "321", true), true),
                                         // Root.AttachedProp='AttachedValue'
                                         new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
                                                 rootType, "AttachedProp", nsSubChildType),
-                                            new XamlAstTextNode(ni, "AttachedValue", true)),
+                                            new XamlAstTextNode(ni, "AttachedValue", true), true),
                                     }
                                 },
                                 new XamlAstTextNode(ni, "\n        "),
@@ -153,7 +153,7 @@ namespace XamlParserTests
                                     new[]
                                     {
                                         new XamlAstTextNode(ni, "DottedValue")
-                                    }),
+                                    }, false),
                                 new XamlAstTextNode(ni, "\n        "),
                                 // <Root.AttachedDottedProp>AttachedValue</Root.AttachedDottedProp>
                                 new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
@@ -161,7 +161,7 @@ namespace XamlParserTests
                                     new[]
                                     {
                                         new XamlAstTextNode(ni, "AttachedValue")
-                                    }),
+                                    }, false),
                                 new XamlAstTextNode(ni, "\n        "),
                                 //<Child.NodeListProp>
                                 new XamlAstXamlPropertyValueNode(ni, new XamlAstNamePropertyReference(ni,
@@ -175,7 +175,7 @@ namespace XamlParserTests
                                         // <SubChild/>
                                         new XamlAstObjectNode(ni, subChildType),
                                         new XamlAstTextNode(ni, "\n        ")
-                                    }),
+                                    }, false),
                                 new XamlAstTextNode(ni, "\n    "),
                             }
                         },


### PR DESCRIPTION
[Collection syntax](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/advanced/xaml-syntax-in-detail?view=netframeworkdesktop-4.8#collection-syntax) in XAML should only be supported when setting property values using property element syntax and not attribute syntax.

Adds a property to `XamlAstXamlPropertyValueNode` to indicate whether the property value came from an attribute, and a property to `PropertySetterBinderParameters` to indicate whether a setter can be used from an attribute.

The `AdderSetter`s set `PropertySetterBinderParameters.AllowAttributeSyntax` to false, which disallows their usage from attribute `XamlAstXamlPropertyValueNode`s.

Updated the unit tests to ensure that markup extensions cannot now be used to add items to read-only collections (but can be used to assign lists to read-write collection properties).

Required for https://github.com/AvaloniaUI/Avalonia/issues/10946