### PR TITLE
Allow defining types/members with internal visibility

### DIFF
--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -718,12 +718,12 @@ namespace XamlX.Ast
             var buildMethod = subType.DefineMethod(so, new[]
             {
                 isp
-            }, "Build", true, true, false);
+            }, "Build", XamlVisibility.Public, true, false);
             CompileBuilder(new ILEmitContext(buildMethod.Generator, context.Configuration,
                 context.EmitMappings, runtimeContext: context.RuntimeContext,
                 contextLocal: buildMethod.Generator.DefineLocal(context.RuntimeContext.ContextType),
-                createSubType: (s, type) => subType.DefineSubType(type, s, false),
-                defineDelegateSubType: (s, returnType, parameters) => subType.DefineDelegateSubType(s, false, returnType, parameters),
+                createSubType: (s, type) => subType.DefineSubType(type, s, XamlVisibility.Private),
+                defineDelegateSubType: (s, returnType, parameters) => subType.DefineDelegateSubType(s, XamlVisibility.Private, returnType, parameters),
                 file: context.File,
                 emitters: context.Emitters));
 

--- a/src/XamlX/Compiler/XamlImperativeCompiler.cs
+++ b/src/XamlX/Compiler/XamlImperativeCompiler.cs
@@ -35,12 +35,12 @@ namespace XamlX.Compiler
         /// </summary>
         public IXamlMethodBuilder<TBackendEmitter> DefinePopulateMethod(IXamlTypeBuilder<TBackendEmitter> typeBuilder,
             XamlDocument doc,
-            string name, bool isPublic)
+            string name, XamlVisibility visibility)
         {
             var rootGrp = (XamlValueWithManipulationNode)doc.Root;
             return typeBuilder.DefineMethod(_configuration.WellKnownTypes.Void,
                 new[] { _configuration.TypeMappings.ServiceProvider, rootGrp.Type.GetClrType() },
-                name, isPublic, true, false);
+                name, visibility, true, false);
         }
 
         /// <summary>
@@ -48,11 +48,11 @@ namespace XamlX.Compiler
         /// </summary>
         public IXamlMethodBuilder<TBackendEmitter> DefineBuildMethod(IXamlTypeBuilder<TBackendEmitter> typeBuilder,
             XamlDocument doc,
-            string name, bool isPublic)
+            string name, XamlVisibility visibility)
         {
             var rootGrp = (XamlValueWithManipulationNode)doc.Root;
             return typeBuilder.DefineMethod(rootGrp.Type.GetClrType(),
-                new[] { _configuration.TypeMappings.ServiceProvider }, name, isPublic, true, false);
+                new[] { _configuration.TypeMappings.ServiceProvider }, name, visibility, true, false);
         }
 
         public void Compile(XamlDocument doc, IXamlTypeBuilder<TBackendEmitter> typeBuilder, IXamlType contextType,
@@ -61,16 +61,16 @@ namespace XamlX.Compiler
         {
             var rootGrp = (XamlValueWithManipulationNode)doc.Root;
             Compile(doc, contextType,
-                DefinePopulateMethod(typeBuilder, doc, populateMethodName, true),
+                DefinePopulateMethod(typeBuilder, doc, populateMethodName, XamlVisibility.Public),
                 createMethodName == null ?
                     null :
-                    DefineBuildMethod(typeBuilder, doc, createMethodName, true),
+                    DefineBuildMethod(typeBuilder, doc, createMethodName, XamlVisibility.Public),
                 _configuration.TypeMappings.XmlNamespaceInfoProvider == null ?
                     null :
                     typeBuilder.DefineSubType(_configuration.WellKnownTypes.Object,
-                        namespaceInfoClassName, false),
-                (name, bt) => typeBuilder.DefineSubType(bt, name, false),
-                (s, returnType, parameters) => typeBuilder.DefineDelegateSubType(s, false, returnType, parameters),
+                        namespaceInfoClassName, XamlVisibility.Private),
+                (name, bt) => typeBuilder.DefineSubType(bt, name, XamlVisibility.Private),
+                (s, returnType, parameters) => typeBuilder.DefineDelegateSubType(s, XamlVisibility.Private, returnType, parameters),
                 baseUri, fileSource);
         }
 

--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -136,13 +136,13 @@ namespace XamlX.IL.Emitters
                     context.Configuration.WellKnownTypes.Void,
                     new[] { parentType }.Concat(valueTypes),
                     "DynamicSetter_" + (cache.MethodByCacheKey.Count + 1),
-                    true, true, false);
+                    XamlVisibility.Public, true, false);
 
                 var newContext = new ILEmitContext(
                     method.Generator, context.Configuration, context.EmitMappings, context.RuntimeContext,
                     null,
-                    (s, type) => cache.SettersType.DefineSubType(type, s, false),
-                    (s, returnType, parameters) => cache.SettersType.DefineDelegateSubType(s, false, returnType, parameters),
+                    (s, type) => cache.SettersType.DefineSubType(type, s, XamlVisibility.Private),
+                    (s, returnType, parameters) => cache.SettersType.DefineDelegateSubType(s, XamlVisibility.Private, returnType, parameters),
                     context.File,
                     context.Emitters);
 

--- a/src/XamlX/IL/NamespaceInfoProvider.cs
+++ b/src/XamlX/IL/NamespaceInfoProvider.cs
@@ -22,8 +22,8 @@ namespace XamlX.IL
             var nsInfoType = roDictionaryType.GenericArguments[1].GenericArguments[0];
 
             typeBuilder.AddInterfaceImplementation(nsInfoProviderType);
-            var namespacesField = typeBuilder.DefineField(roDictionaryType, "_xmlNamespaces", false, false);
-            var singletonField = typeBuilder.DefineField(nsInfoProviderType, "Singleton", true, true);
+            var namespacesField = typeBuilder.DefineField(roDictionaryType, "_xmlNamespaces", XamlVisibility.Private, false);
+            var singletonField = typeBuilder.DefineField(nsInfoProviderType, "Singleton", XamlVisibility.Public, true);
 
             IXamlMethod EmitCreateNamespaceInfoMethod()
             {
@@ -32,7 +32,7 @@ namespace XamlX.IL
                     nsInfoType,
                     new[] { configuration.WellKnownTypes.String, configuration.WellKnownTypes.String },
                     "CreateNamespaceInfo",
-                    false, true, false);
+                    XamlVisibility.Private, true, false);
 
                 // return new XamlXmlNamespaceInfoV1() { ClrNamespace = arg0, ClrAssemblyName = arg1 }
                 method.Generator
@@ -57,7 +57,7 @@ namespace XamlX.IL
                     roDictionaryType,
                     null,
                     "CreateNamespaces",
-                    false, true, false);
+                    XamlVisibility.Private, true, false);
 
                 var roListType = configuration.TypeSystem.FindType("System.Collections.Generic.IReadOnlyList`1")
                     .MakeGenericType(nsInfoType);
@@ -128,7 +128,7 @@ namespace XamlX.IL
                     roDictionaryType,
                     null,
                     getNamespacesInterfaceMethod.Name,
-                    true, false, true);
+                    XamlVisibility.Public, false, true);
 
                 var hasValueLabel = method.Generator.DefineLabel();
 

--- a/src/XamlX/IL/RuntimeContext.cs
+++ b/src/XamlX/IL/RuntimeContext.cs
@@ -78,7 +78,7 @@ namespace XamlX.IL
             XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult> emitMappings)
         {
             var so = typeSystem.GetType("System.Object");
-            var builder = parentBuilder.DefineSubType(so, "Context", true);
+            var builder = parentBuilder.DefineSubType(so, "Context", XamlVisibility.Public);
             
             builder.DefineGenericParameters(new[]
             {
@@ -88,14 +88,14 @@ namespace XamlX.IL
                         IsClass = true
                     })
             });
-            var rootObjectField = builder.DefineField(builder.GenericParameters[0], "RootObject", true, false);
-            var intermediateRootObjectField = builder.DefineField(so, XamlRuntimeContextDefintion.IntermediateRootObjectFieldName, true, false);
-            _parentServiceProviderField = builder.DefineField(mappings.ServiceProvider, "_sp", false, false);
+            var rootObjectField = builder.DefineField(builder.GenericParameters[0], "RootObject", XamlVisibility.Public, false);
+            var intermediateRootObjectField = builder.DefineField(so, XamlRuntimeContextDefintion.IntermediateRootObjectFieldName, XamlVisibility.Public, false);
+            _parentServiceProviderField = builder.DefineField(mappings.ServiceProvider, "_sp", XamlVisibility.Private, false);
             if (mappings.InnerServiceProviderFactoryMethod != null)
-                _innerServiceProviderField = builder.DefineField(mappings.ServiceProvider, "_innerSp", false, false);
+                _innerServiceProviderField = builder.DefineField(mappings.ServiceProvider, "_innerSp", XamlVisibility.Private, false);
 
             var staticProvidersField = builder.DefineField(typeSystem.GetType("System.Object").MakeArrayType(1),
-                "_staticProviders", false, false);
+                "_staticProviders", XamlVisibility.Private, false);
             
             
             var systemType = typeSystem.GetType("System.Type");
@@ -158,13 +158,13 @@ namespace XamlX.IL
                 builder.AddInterfaceImplementation(mappings.ParentStackProvider);
                 var objectListType = typeSystem.GetType("System.Collections.Generic.List`1")
                     .MakeGenericType(new[] {typeSystem.GetType("System.Object")});
-                ParentListField = builder.DefineField(objectListType, XamlRuntimeContextDefintion.ParentListFieldName, true, false);
+                ParentListField = builder.DefineField(objectListType, XamlRuntimeContextDefintion.ParentListFieldName, XamlVisibility.Public, false);
 
                 var enumerator = EmitParentEnumerable(typeSystem, parentBuilder, mappings);
                 CreateCallbacks.Add(enumerator.createCallback);
                 var parentStackEnumerableField = builder.DefineField(
                     typeSystem.GetType("System.Collections.Generic.IEnumerable`1").MakeGenericType(new[]{so}),
-                    "_parentStackEnumerable", false, false);
+                    "_parentStackEnumerable", XamlVisibility.Private, false);
 
                 ImplementInterfacePropertyGetter(builder, mappings.ParentStackProvider, "Parents")
                     .Generator.LdThisFld(parentStackEnumerableField).Ret();
@@ -186,8 +186,8 @@ namespace XamlX.IL
             if (mappings.ProvideValueTarget != null)
             {
                 builder.AddInterfaceImplementation(mappings.ProvideValueTarget);
-                PropertyTargetObject = builder.DefineField(so, XamlRuntimeContextDefintion.ProvideTargetObjectName, true, false);
-                PropertyTargetProperty = builder.DefineField(so, XamlRuntimeContextDefintion.ProvideTargetPropertyName, true, false);
+                PropertyTargetObject = builder.DefineField(so, XamlRuntimeContextDefintion.ProvideTargetObjectName, XamlVisibility.Public, false);
+                PropertyTargetProperty = builder.DefineField(so, XamlRuntimeContextDefintion.ProvideTargetPropertyName, XamlVisibility.Public, false);
                 ImplementInterfacePropertyGetter(builder, mappings.ProvideValueTarget, "TargetObject")
                     .Generator.LdThisFld(PropertyTargetObject).Ret();
                 ImplementInterfacePropertyGetter(builder, mappings.ProvideValueTarget, "TargetProperty")
@@ -198,11 +198,11 @@ namespace XamlX.IL
             IXamlField baseUriField = null;
             if (mappings.UriContextProvider != null)
             {
-                baseUriField = builder.DefineField(systemUri, "_baseUri", false, false);
+                baseUriField = builder.DefineField(systemUri, "_baseUri", XamlVisibility.Private, false);
                 builder.AddInterfaceImplementation(mappings.UriContextProvider);
-                var getter = builder.DefineMethod(systemUri, new IXamlType[0], "get_BaseUri", true, false, true);
+                var getter = builder.DefineMethod(systemUri, new IXamlType[0], "get_BaseUri", XamlVisibility.Public, false, true);
                 var setter = builder.DefineMethod(typeSystem.GetType("System.Void"), new[] {systemUri},
-                    "set_BaseUri", true, false, true);
+                    "set_BaseUri", XamlVisibility.Public, false, true);
 
                 getter.Generator
                     .LdThisFld(baseUriField)
@@ -222,7 +222,7 @@ namespace XamlX.IL
             builder.AddInterfaceImplementation(mappings.ServiceProvider);
             var getServiceMethod = builder.DefineMethod(so,
                 new[] {systemType},
-                "GetService", true, false, true);
+                "GetService", XamlVisibility.Public, false, true);
 
             ownServices = ownServices.Where(s => s != null).ToList();
 
@@ -401,7 +401,7 @@ namespace XamlX.IL
                 .MakeGenericType(new[] {so});
             
             var pushParentGenerator =
-                builder.DefineMethod(@void, new[] {so}, XamlRuntimeContextDefintion.PushParentMethodName, true, false, false)
+                builder.DefineMethod(@void, new[] {so}, XamlRuntimeContextDefintion.PushParentMethodName, XamlVisibility.Public, false, false)
                 .Generator;
 
             pushParentGenerator.LdThisFld(ParentListField)
@@ -417,7 +417,7 @@ namespace XamlX.IL
                     .Ret();
             }
             
-            var pop = builder.DefineMethod(@void, new IXamlType[0], XamlRuntimeContextDefintion.PopParentMethodName, true, false, false)
+            var pop = builder.DefineMethod(@void, new IXamlType[0], XamlRuntimeContextDefintion.PopParentMethodName, XamlVisibility.Public, false, false)
                 .Generator;
 
             var idx = pop.DefineLocal(ts.GetType("System.Int32"));
@@ -450,7 +450,7 @@ namespace XamlX.IL
             var prefix = type.Namespace + "." + type.Name + ".";
             var originalGetter = type.FindMethod(m => m.Name == "get_" + name);
             var gen = builder.DefineMethod(originalGetter.ReturnType, new IXamlType[0],
-                prefix + "get_" + name, false, false,
+                prefix + "get_" + name, XamlVisibility.Private, false,
                 true, originalGetter);
             builder.DefineProperty(originalGetter.ReturnType,prefix+ name, null, gen);
             return gen;
@@ -474,7 +474,7 @@ namespace XamlX.IL
             {
                 var original = tdc.FindMethod(m => m.Name == name);
                 builder.DefineMethod(original.ReturnType, original.Parameters, tdcPrefix + name, 
-                        false, false, true,
+                        XamlVisibility.Private, false, true,
                         original)
                     .Generator
                     .Emit(OpCodes.Newobj,
@@ -493,15 +493,15 @@ namespace XamlX.IL
         {
             var so = typeSystem.GetType("System.Object");
             var enumerableBuilder =
-                parentBuilder.DefineSubType(typeSystem.GetType("System.Object"), "ParentStackEnumerable", false);
+                parentBuilder.DefineSubType(typeSystem.GetType("System.Object"), "ParentStackEnumerable", XamlVisibility.Private);
             var enumerableType = typeSystem.GetType("System.Collections.Generic.IEnumerable`1")
                 .MakeGenericType(new[] {typeSystem.GetType("System.Object")});
             enumerableBuilder.AddInterfaceImplementation(enumerableType);
 
             var enumerableParentList =
-                enumerableBuilder.DefineField(ParentListField.FieldType, "_parentList", false, false);
+                enumerableBuilder.DefineField(ParentListField.FieldType, "_parentList", XamlVisibility.Private, false);
             var enumerableParentProvider =
-                enumerableBuilder.DefineField(mappings.ServiceProvider, "_parentSP", false, false);
+                enumerableBuilder.DefineField(mappings.ServiceProvider, "_parentSP", XamlVisibility.Private, false);
             
             var enumerableCtor = enumerableBuilder.DefineConstructor(false, enumerableParentList.FieldType, enumerableParentProvider.FieldType);
             enumerableCtor.Generator
@@ -520,24 +520,24 @@ namespace XamlX.IL
             var enumeratorObjectType = typeSystem.GetType("System.Collections.Generic.IEnumerator`1")
                 .MakeGenericType(new[] {so});
 
-            var enumeratorBuilder = enumerableBuilder.DefineSubType(so, "Enumerator", true);
+            var enumeratorBuilder = enumerableBuilder.DefineSubType(so, "Enumerator", XamlVisibility.Public);
             enumeratorBuilder.AddInterfaceImplementation(enumeratorObjectType);
 
 
             
-            var state = enumeratorBuilder.DefineField(typeSystem.GetType("System.Int32"), "_state", false, false);
+            var state = enumeratorBuilder.DefineField(typeSystem.GetType("System.Int32"), "_state", XamlVisibility.Private, false);
             
             
             var parentList =
-                enumeratorBuilder.DefineField(ParentListField.FieldType, "_parentList", false, false);
+                enumeratorBuilder.DefineField(ParentListField.FieldType, "_parentList", XamlVisibility.Private, false);
             var parentProvider =
-                enumeratorBuilder.DefineField(mappings.ServiceProvider, "_parentSP", false, false);
+                enumeratorBuilder.DefineField(mappings.ServiceProvider, "_parentSP", XamlVisibility.Private, false);
             var listType = typeSystem.GetType("System.Collections.Generic.List`1")
                 .MakeGenericType(new[] {so});
-            var list = enumeratorBuilder.DefineField(listType, "_list", false, false);
-            var listIndex = enumeratorBuilder.DefineField(typeSystem.GetType("System.Int32"), "_listIndex", false, false);
-            var current = enumeratorBuilder.DefineField(so, "_current", false, false);
-            var parentEnumerator = enumeratorBuilder.DefineField(enumeratorObjectType, "_parentEnumerator", false, false);
+            var list = enumeratorBuilder.DefineField(listType, "_list", XamlVisibility.Private, false);
+            var listIndex = enumeratorBuilder.DefineField(typeSystem.GetType("System.Int32"), "_listIndex", XamlVisibility.Private, false);
+            var current = enumeratorBuilder.DefineField(so, "_current", XamlVisibility.Private, false);
+            var parentEnumerator = enumeratorBuilder.DefineField(enumeratorObjectType, "_parentEnumerator", XamlVisibility.Private, false);
             var enumeratorCtor = enumeratorBuilder.DefineConstructor(false, parentList.FieldType, parentProvider.FieldType);
                 enumeratorCtor.Generator
                 .Emit(OpCodes.Ldarg_0)
@@ -551,7 +551,7 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ret);
             
             var currentGetter = enumeratorBuilder.DefineMethod(so, new IXamlType[0],
-                "get_Current", true, false, true);
+                "get_Current", XamlVisibility.Public, false, true);
             enumeratorBuilder.DefineProperty(so, "Current", null, currentGetter);
             currentGetter.Generator
                 .Emit(OpCodes.Ldarg_0)
@@ -559,14 +559,14 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ret);
 
             enumeratorBuilder.DefineMethod(typeSystem.FindType("System.Void"), new IXamlType[0],
-                    enumeratorObjectType.FullName+".Reset", false, false,
+                    enumeratorObjectType.FullName+".Reset", XamlVisibility.Private, false,
                     true, enumeratorObjectType.FindMethod(m => m.Name == "Reset")).Generator
                 .Emit(OpCodes.Newobj,
                     typeSystem.FindType("System.NotSupportedException").FindConstructor(new List<IXamlType>()))
                 .Emit(OpCodes.Throw);
 
             var disposeGen = enumeratorBuilder.DefineMethod(typeSystem.FindType("System.Void"), new IXamlType[0], 
-                "System.IDisposable.Dispose", false, false, true,
+                "System.IDisposable.Dispose", XamlVisibility.Private, false, true,
                 typeSystem.GetType("System.IDisposable").FindMethod(m => m.Name == "Dispose")).Generator;
             var disposeRet = disposeGen.DefineLabel();
             disposeGen
@@ -581,7 +581,7 @@ namespace XamlX.IL
 
             var boolType = typeSystem.GetType("System.Boolean");
             var moveNext = enumeratorBuilder.DefineMethod(boolType, new IXamlType[0],
-                enumeratorObjectType.FullName+".MoveNext", false,
+                enumeratorObjectType.FullName+".MoveNext", XamlVisibility.Private,
                 false, true,
                 enumeratorObjectType.FindMethod(m => m.Name == "MoveNext")).Generator;
 
@@ -655,7 +655,7 @@ namespace XamlX.IL
                 .Ldarg_0().Ldc_I4(stateEof).Stfld(state)
                 .Ldc_I4(0).Ret();
                 
-            var createEnumerator = enumerableBuilder.DefineMethod(enumeratorObjectType, new IXamlType[0], "GetEnumerator", true, false,
+            var createEnumerator = enumerableBuilder.DefineMethod(enumeratorObjectType, new IXamlType[0], "GetEnumerator", XamlVisibility.Public, false,
                     true);
             createEnumerator.Generator
                 .LdThisFld(enumerableParentList)
@@ -664,7 +664,7 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ret);
 
             enumerableBuilder.DefineMethod(enumeratorType, new IXamlType[0],
-                    "System.Collections.IEnumerable.GetEnumerator", false, false, true,
+                    "System.Collections.IEnumerable.GetEnumerator", XamlVisibility.Private, false, true,
                     typeSystem.GetType("System.Collections.IEnumerable").FindMethod(m => m.Name == "GetEnumerator"))
                 .Generator
                 .Ldarg_0()

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -165,19 +165,30 @@ namespace XamlX.TypeSystem
 #if !XAMLX_INTERNAL
     public
 #endif
+    enum XamlVisibility
+    {
+        Public,
+        Assembly,
+        Private
+    }
+
+#if !XAMLX_INTERNAL
+    public
+#endif
     interface IXamlTypeBuilder<TBackendEmitter> : IXamlType
     {
-        IXamlField DefineField(IXamlType type, string name, bool isPublic, bool isStatic);
+        IXamlField DefineField(IXamlType type, string name, XamlVisibility visibility, bool isStatic);
         void AddInterfaceImplementation(IXamlType type);
 
-        IXamlMethodBuilder<TBackendEmitter> DefineMethod(IXamlType returnType, IEnumerable<IXamlType> args, string name, bool isPublic, bool isStatic,
-            bool isInterfaceImpl, IXamlMethod overrideMethod = null);
+        IXamlMethodBuilder<TBackendEmitter> DefineMethod(IXamlType returnType, IEnumerable<IXamlType> args, string name,
+            XamlVisibility visibility, bool isStatic, bool isInterfaceImpl, IXamlMethod overrideMethod = null);
 
         IXamlProperty DefineProperty(IXamlType propertyType, string name, IXamlMethod setter, IXamlMethod getter);
         IXamlConstructorBuilder<TBackendEmitter> DefineConstructor(bool isStatic, params IXamlType[] args);
         IXamlType CreateType();
-        IXamlTypeBuilder<TBackendEmitter> DefineSubType(IXamlType baseType, string name, bool isPublic);
-        IXamlTypeBuilder<TBackendEmitter> DefineDelegateSubType(string name, bool isPublic, IXamlType returnType, IEnumerable<IXamlType> parameterTypes);
+        IXamlTypeBuilder<TBackendEmitter> DefineSubType(IXamlType baseType, string name, XamlVisibility visibility);
+        IXamlTypeBuilder<TBackendEmitter> DefineDelegateSubType(string name, XamlVisibility visibility,
+            IXamlType returnType, IEnumerable<IXamlType> parameterTypes);
         void DefineGenericParameters(IReadOnlyList<KeyValuePair<string, XamlGenericParameterConstraint>> names);
     }
 


### PR DESCRIPTION
Replace the `bool isPublic` parameter in the various `DefineXxx` methods with a `XamlVisibility visibility` parameter. This new enum allows the member to be defined with assembly (internal) visibility.

This change is necessary to make the nested `NamespaceInfo` classes in Avalonia `internal`, to remove them completely from the public API.