### PR TITLE
Fixes #45 where a derived class cannot override the Content attribute for a base class.

### DIFF
--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -74,10 +74,6 @@ namespace XamlX.Transform
             if (_contentPropertyCache.TryGetValue(type.Id, out var found))
                 return found;
 
-            // Check the base type first, we'll need to throw on duplicate Content property later
-            if (type.BaseType != null)
-                found = FindContentProperty(type.BaseType);
-
             foreach (var contentAttributeOnType in GetCustomAttribute(type, TypeMappings.ContentAttributes))
             {
                 if (contentAttributeOnType.Properties.Count == 0)
@@ -94,7 +90,7 @@ namespace XamlX.Transform
 
                     if (found != null && !contentProperty.Equals(found))
                         throw new XamlTypeSystemException(
-                            "Content (or substitute) attribute is declared on multiple properties of " + type.GetFqn());
+                            "Content attribute is declared on multiple properties of " + type.GetFqn());
                     found = contentProperty;
                 }
             }
@@ -105,10 +101,14 @@ namespace XamlX.Transform
                 {
                     if (found != null && !p.Equals(found))
                         throw new XamlTypeSystemException(
-                            "Content (or substitute) attribute is declared on multiple properties of " + type.GetFqn());
+                            "Content attribute is declared on multiple properties of " + type.GetFqn());
                     found = p;
                 }
             }
+
+            // Fall back to a Content attribute found on a base type
+            if ((found == null) && (type.BaseType != null))
+                found = FindContentProperty(type.BaseType);
 
             return _contentPropertyCache[type.Id] = found;
         }

--- a/tests/XamlParserTests/ContentAttributeTests.cs
+++ b/tests/XamlParserTests/ContentAttributeTests.cs
@@ -55,7 +55,7 @@ namespace XamlParserTests
         [Fact]
         public void Compiler_Should_Fail_To_Build_Xaml_When_Multiple_ContentAttributes_Defined()
         {
-            Assert.Throws<XamlTypeSystemException>(() => Compile(@"
+            Assert.Throws<XamlParseException>(() => Compile(@"
 <SimpleClassWithTwoContentAttributes xmlns='test'>123</SimpleClassWithTwoContentAttributes>"));
         }
 

--- a/tests/XamlParserTests/ContentAttributeTests.cs
+++ b/tests/XamlParserTests/ContentAttributeTests.cs
@@ -1,0 +1,63 @@
+using XamlX;
+using Xunit;
+
+namespace XamlParserTests
+{
+    public class SimpleClassWithContentAttribute
+    {
+        [Content]
+        public string Text { get; set; }
+    }
+
+    public class SubClassWithContentAttributeOverride : SimpleClassWithContentAttribute
+    {
+        [Content]
+        public string OtherText { get; set; }
+    }
+
+    public class SimpleClassWithTwoContentAttributes
+    {
+        [Content]
+        public string Text { get; set; }
+
+        [Content]
+        public string OtherText { get; set; }
+    }
+
+    public class ContentAttributeTests : CompilerTestBase
+    {
+        
+        [Fact]
+        public void Compiler_Should_Support_ContentAttribute()
+        {
+            var comp = Compile(@"<SimpleClassWithContentAttribute xmlns='test'  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>123</SimpleClassWithContentAttribute>");
+
+            var res = (SimpleClassWithContentAttribute)comp.create(null);
+
+            comp.populate(null, res);
+
+            Assert.Equal("123", res.Text);
+        }
+
+        [Fact]
+        public void Compiler_Should_Support_ContentAttribute_Override()
+        {
+            var comp = Compile(@"<SubClassWithContentAttributeOverride xmlns='test'  xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'>123</SubClassWithContentAttributeOverride>");
+
+            var res = (SubClassWithContentAttributeOverride)comp.create(null);
+
+            comp.populate(null, res);
+
+            Assert.Null(res.Text);
+            Assert.Equal("123", res.OtherText);
+        }
+        
+        [Fact]
+        public void Compiler_Should_Fail_To_Build_Xaml_When_Multiple_ContentAttributes_Defined()
+        {
+            Assert.Throws<XamlTypeSystemException>(() => Compile(@"
+<SimpleClassWithTwoContentAttributes xmlns='test'>123</SimpleClassWithTwoContentAttributes>"));
+        }
+
+    }
+}


### PR DESCRIPTION
This is intended to fix:
- https://github.com/kekekeks/XamlX/issues/45

We have a need for this as well.  The change is basically to not look at the base types for a Content attribute unless none is found on the current type.  It will still look for duplicates on the current type.

I believe this should resolve the issue.