### PR TITLE
Warning fixes

### DIFF
--- a/src/BenchmarksCompiler/BenchmarksCompiler.csproj
+++ b/src/BenchmarksCompiler/BenchmarksCompiler.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/XamlX/Ast/Xaml.cs
+++ b/src/XamlX/Ast/Xaml.cs
@@ -96,7 +96,14 @@ namespace XamlX.Ast
         /// </summary>
         public bool PreserveWhitespace { get; }
 
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="XamlAstTextNode"/>.
+        /// </summary>
+        /// <param name="lineInfo">The line information for the node.</param>
+        /// <param name="text">The node text.</param>
         /// <param name="preserveWhitespace">True if XAML whitespace normalization should NOT be applied to this text value (i.e. xml:space="preserve" or attribute values).</param>
+        /// <param name="type">The type of the node.</param>
         public XamlAstTextNode(IXamlLineInfo lineInfo, string text, bool preserveWhitespace = false, IXamlType type = null) : base(lineInfo)
         {
             Text = text;

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -55,7 +55,7 @@ namespace XamlX.IL
             return n;
         }
 
-        SreType? ResolveType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? t)
+        SreType ResolveType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type t)
         {
             if (t is null)
                 return null;
@@ -720,7 +720,8 @@ namespace XamlX.IL
                     args.Cast<SreType>().Select(t => t.Type).ToArray());
                 return new SreConstructorBuilder(_system, ctor);
             }
-            
+
+            [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = TrimmingMessages.GeneratedTypes)]
             public IXamlType CreateType() => new SreType(_system, null, _tb.CreateTypeInfo());
 
             [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = TrimmingMessages.GeneratedTypes)]

--- a/tests/Tests.Common.props
+++ b/tests/Tests.Common.props
@@ -7,7 +7,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" Condition="$(TargetFramework) != 'netstandard2.0'" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/XamlParserTests/ServiceProviderTests.cs
+++ b/tests/XamlParserTests/ServiceProviderTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using XamlX.Runtime;
@@ -136,6 +137,7 @@ namespace XamlParserTests
             }, null);
         }
 
+        [SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "Not a theory, used in XAML tests")]
         public static void SetAttachedProperty(ServiceProviderTestsClass target, string value)
         {
             


### PR DESCRIPTION
Two small commits to fix all warnings in the solution:

- The first commit fixes only compiler/analyzer errors, so they'll also be fixed in Avalonia.

- While I was at it, the second commit fixes the remaining restore warnings by not referencing the test runner from the `netstandard2.0` build, since they always run with a specific framework.
