### PR TITLE
Fix one occurrence of the xunit1013 warning

### DIFF
--- a/tests/XamlParserTests/ConvertersTests.cs
+++ b/tests/XamlParserTests/ConvertersTests.cs
@@ -133,7 +133,7 @@ namespace XamlParserTests
                 typeof(ConvertersTestClass).ToString());
         }
         
-        public void CheckConversion(string property, string value, string expected)
+        private void CheckConversion(string property, string value, string expected)
         {
             var res = (ConvertersTestClass) CompileAndRun($@"
 <ConvertersTestClass


### PR DESCRIPTION
This is a tiny fix that address the Xunit analyzer warning [1013](https://xunit.net/xunit.analyzers/rules/xUnit1013). The method is not a theory but rather a private helper that is called by multiple other facts.