### PR TITLE
fix: `CecilType.ArrayElementType` returns wrong type for arrays

### DIFF
--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -157,7 +157,7 @@ namespace XamlX.TypeSystem
 
             public IXamlType ArrayElementType =>
                 _arrayType ?? (_arrayType =
-                    IsArray ? TypeSystem.Resolve(Definition) : null);
+                    IsArray ? TypeSystem.Resolve(Reference.GetElementType()) : null);
 
             public IXamlType MakeArrayType(int dimensions) => TypeSystem.Resolve(Reference.MakeArrayType(dimensions));
 

--- a/tests/CecilTests/CecilTests.cs
+++ b/tests/CecilTests/CecilTests.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using Mono.Cecil;
 using XamlX.TypeSystem;
 using Xunit;
 
@@ -22,6 +21,7 @@ namespace XamlParserTests
     public class CecilTestType
     {
         public GenericType<string> GenericStringField;
+        public string[] ArrayElementType;
     }
     
     public class CecilTests : CompilerTestBase
@@ -48,7 +48,15 @@ namespace XamlParserTests
             Assert.Equal("System.String", p.Getter.ReturnType.FullName);
             Assert.Equal("System.String", p.Setter.Parameters[0].FullName);
 
+        }
 
+        [Fact]
+        public void ArrayElementType_Is_Correctly_Handled()
+        {
+            var wut = Configuration.TypeSystem.GetType("XamlParserTests.CecilTestType");
+            var af = wut.Fields.First(x => x.Name == nameof(CecilTestType.ArrayElementType));
+            Assert.True(af.FieldType?.IsArray);
+            Assert.Equal("System.String", af.FieldType.ArrayElementType?.FullName);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #89
Fixes https://github.com/AvaloniaUI/Avalonia/issues/11946