### PR TITLE
Advanced deferred customization

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,9 +9,9 @@ jobs:
           version: 2.1.818
 
       - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 6.0.100'
+        displayName: 'Use .NET Core SDK 8.0.203'
         inputs:
-          version: 6.0.100
+          version: 8.0.203
 
       - task: CmdLine@2
         displayName: 'Run Tests'
@@ -41,9 +41,9 @@ jobs:
           version: 2.1.818
 
       - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 6.0.100'
+        displayName: 'Use .NET Core SDK 8.0.203'
         inputs:
-          version: 6.0.100
+          version: 8.0.203
 
       - task: CmdLine@2
         displayName: 'Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,14 +4,15 @@ jobs:
       vmImage: 'ubuntu-20.04'
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 2.1.818'
-        inputs:
-          version: 2.1.818
-
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 8.0.203'
+        displayName: 'Use .NET SDK 8.0.203'
         inputs:
           version: 8.0.203
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET Runtime 6.0'
+        inputs:
+          packageType: runtime
+          version: 6.0.x
 
       - task: CmdLine@2
         displayName: 'Run Tests'
@@ -20,8 +21,9 @@ jobs:
             mono --version
             dotnet --info
             dotnet build
-            dotnet test -f netcoreapp2.1 --logger "trx" --results-directory artifacts/test-results
-            dotnet test -f net47 --logger "trx" --results-directory artifacts/test-results
+            dotnet test -f net8.0 --logger "trx" --results-directory artifacts/test-results
+            dotnet test -f net6.0 --logger "trx" --results-directory artifacts/test-results
+            dotnet test -f net47  --logger "trx" --results-directory artifacts/test-results
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: 'VSTest'
@@ -36,14 +38,15 @@ jobs:
       SolutionDir: '$(Build.SourcesDirectory)'
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 2.1.818'
-        inputs:
-          version: 2.1.818
-
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 8.0.203'
+        displayName: 'Use .NET SDK 8.0.203'
         inputs:
           version: 8.0.203
+          
+      - task: UseDotNet@2
+        displayName: 'Use .NET Runtime 6.0'
+        inputs:
+          packageType: runtime
+          version: 6.0.x
 
       - task: CmdLine@2
         displayName: 'Run Tests'
@@ -51,8 +54,9 @@ jobs:
           script: |
             dotnet --info
             dotnet build
-            dotnet test -f netcoreapp2.1 --logger "trx" --results-directory artifacts/test-results
-            dotnet test -f net47 --logger "trx" --results-directory artifacts/test-results
+            dotnet test -f net8.0 --logger "trx" --results-directory artifacts/test-results
+            dotnet test -f net6.0 --logger "trx" --results-directory artifacts/test-results
+            dotnet test -f net47  --logger "trx" --results-directory artifacts/test-results
 
       - task: PublishTestResults@2
         inputs:

--- a/src/BenchmarksCompiler/BenchmarksCompiler.csproj
+++ b/src/BenchmarksCompiler/BenchmarksCompiler.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/XamlX.IL.Cecil/CecilFunctionPointer.cs
+++ b/src/XamlX.IL.Cecil/CecilFunctionPointer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using Mono.Cecil;
+
+namespace XamlX.TypeSystem;
+
+partial class CecilTypeSystem
+{
+    internal class CecilFunctionPointerType : IXamlType, ITypeReference
+    {
+        private readonly FunctionPointerType _reference;
+
+        public CecilFunctionPointerType(FunctionPointerType reference) => _reference = reference;
+
+        public TypeReference Reference => _reference;
+        public object Id => _reference.FullName;
+        public string Name => _reference.Name;
+        public string FullName => _reference.FullName;
+        public string Namespace => _reference.Namespace;
+        public bool IsPublic => true;
+        public bool IsNestedPrivate => false;
+        public IXamlAssembly Assembly => null;
+        public IReadOnlyList<IXamlProperty> Properties => Array.Empty<IXamlProperty>();
+        public IReadOnlyList<IXamlEventInfo> Events => Array.Empty<IXamlEventInfo>();
+        public IReadOnlyList<IXamlField> Fields => Array.Empty<IXamlField>();
+        public IReadOnlyList<IXamlMethod> Methods => Array.Empty<IXamlMethod>();
+        public IReadOnlyList<IXamlConstructor> Constructors => Array.Empty<IXamlConstructor>();
+        public IReadOnlyList<IXamlCustomAttribute> CustomAttributes => Array.Empty<IXamlCustomAttribute>();
+        public IReadOnlyList<IXamlType> GenericArguments => Array.Empty<IXamlType>();
+        public IReadOnlyList<IXamlType> Interfaces => Array.Empty<IXamlType>();
+        public IReadOnlyList<IXamlType> GenericParameters => Array.Empty<IXamlType>();
+        public bool IsArray => false;
+        public bool IsValueType => false;
+        public bool IsEnum => false;
+        public bool IsInterface => false;
+        public bool IsFunctionPointer => true;
+        public IXamlType GenericTypeDefinition => null;
+        public IXamlType ArrayElementType => null;
+        public IXamlType BaseType => null;
+        public IXamlType DeclaringType => null;
+
+        public IXamlType MakeGenericType(IReadOnlyList<IXamlType> typeArguments) => throw new InvalidOperationException();
+        public IXamlType MakeArrayType(int dimensions) => throw new InvalidOperationException();
+        public IXamlType GetEnumUnderlyingType() => throw new InvalidOperationException();
+
+        public bool Equals(IXamlType other)
+            => other is CecilFunctionPointerType typedOther &&
+               TypeReferenceEqualityComparer.AreEqual(Reference, typedOther.Reference, CecilTypeComparisonMode.Exact);
+
+        public override bool Equals(object obj) => Equals(obj as IXamlType);
+        public override int GetHashCode() => TypeReferenceEqualityComparer.GetHashCodeFor(Reference, CecilTypeComparisonMode.Exact);
+        public bool IsAssignableFrom(IXamlType type) => Equals(type);
+    }
+}

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -174,6 +174,8 @@ namespace XamlX.TypeSystem
                 return TypeResolveContext.Resolve(Definition.GetEnumUnderlyingType());
             }
 
+            public bool IsFunctionPointer => Definition.IsFunctionPointer;
+
             public bool Equals(IXamlType other)
             {
                 if (!(other is CecilType o))

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -174,6 +174,7 @@ namespace XamlX.TypeSystem
                 return TypeResolveContext.Resolve(Definition.GetEnumUnderlyingType());
             }
 
+            // Note: should always be false, as a TypeDefinition can't be a function pointer.
             public bool IsFunctionPointer => Definition.IsFunctionPointer;
 
             public bool Equals(IXamlType other)

--- a/src/XamlX.IL.Cecil/CecilTypeCache.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeCache.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Mono.Cecil;
 
@@ -21,11 +20,6 @@ internal class CecilTypeCache
 
     public IXamlType Resolve(CecilTypeResolveContext resolveContext, TypeReference reference)
     {
-        if (reference.Name.Contains("RelativeSource"))
-        {
-            
-        }
-        
         if (!_typeReferenceCache.TryGetValue(reference, out var rv))
         {
             TypeDefinition definition = null;
@@ -41,6 +35,10 @@ internal class CecilTypeCache
             if (definition != null)
             {
                 rv = SecondLayerCache(resolveContext, reference, definition);
+            }
+            else if (reference is FunctionPointerType functionPointerType)
+            {
+                rv = new CecilTypeSystem.CecilFunctionPointerType(functionPointerType);
             }
             else
             {

--- a/src/XamlX.IL.Cecil/CecilTypeCache.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeCache.cs
@@ -36,6 +36,7 @@ internal class CecilTypeCache
             {
                 rv = SecondLayerCache(resolveContext, reference, definition);
             }
+            // For a function pointer, definition will always be null, as function pointers never have any TypeDefinition.
             else if (reference is FunctionPointerType functionPointerType)
             {
                 rv = new CecilTypeSystem.CecilFunctionPointerType(functionPointerType);

--- a/src/XamlX.IL.Cecil/XamlX.IL.Cecil.csproj
+++ b/src/XamlX.IL.Cecil/XamlX.IL.Cecil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/XamlX.Parser.GuiLabs/XamlX.Parser.GuiLabs.csproj
+++ b/src/XamlX.Parser.GuiLabs/XamlX.Parser.GuiLabs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     <RootNamespace>XamlX</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/XamlX.Runtime/XamlX.Runtime.csproj
+++ b/src/XamlX.Runtime/XamlX.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <Import Project="../../props/TrimmingEnable.props" />

--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -649,12 +649,17 @@ namespace XamlX.Ast
         }
     }
 
+#nullable enable
+
 #if !XAMLX_INTERNAL
     public
 #endif
     class XamlDeferredContentNode : XamlAstNode, IXamlAstValueNode, IXamlAstEmitableNode<IXamlILEmitter, XamlILNodeEmitResult>
     {
-        private readonly IXamlType _deferredContentCustomizationTypeParameter;
+        private readonly IXamlMethod? _deferredContentCustomization;
+        private readonly IXamlType? _deferredContentCustomizationTypeParameter;
+        private readonly IXamlType _funcType;
+
         public IXamlAstValueNode Value { get; set; }
         public IXamlAstTypeReference Type { get; }
         
@@ -662,11 +667,16 @@ namespace XamlX.Ast
             IXamlType deferredContentCustomizationTypeParameter,
             TransformerConfiguration config) : base(value)
         {
+            _deferredContentCustomization = config.TypeMappings.DeferredContentExecutorCustomization;
             _deferredContentCustomizationTypeParameter = deferredContentCustomizationTypeParameter;
             Value = value;
-            var funcType = config.TypeSystem.GetType("System.Func`2")
+
+            _funcType = config.TypeSystem
+                .GetType("System.Func`2")
                 .MakeGenericType(config.TypeMappings.ServiceProvider, config.WellKnownTypes.Object);
-            Type = new XamlAstClrTypeReference(value, funcType, false);
+
+            var returnType = _deferredContentCustomization?.ReturnType ?? _funcType;
+            Type = new XamlAstClrTypeReference(value, returnType, false);
         }
 
         public override void VisitChildren(Visitor visitor)
@@ -730,30 +740,42 @@ namespace XamlX.Ast
 
             CompileBuilder(subContext, closureInfo);
 
-            var funcType = Type.GetClrType();
-            codeGen
-                .Ldnull()
-                .Ldftn(buildMethod)
-                .Newobj(funcType.Constructors.FirstOrDefault(ct =>
-                    ct.Parameters.Count == 2 && ct.Parameters[0].Equals(context.Configuration.WellKnownTypes.Object)));
+            var customization = _deferredContentCustomization;
+
+            if (_deferredContentCustomizationTypeParameter is not null)
+                customization = customization?.MakeGenericMethod(new[] { _deferredContentCustomizationTypeParameter });
+
+            if (customization is not null && IsFunctionPointerLike(customization.Parameters[0]))
+            {
+                // &Build
+                codeGen
+                    .Ldftn(buildMethod);
+            }
+            else
+            {
+                // new Func<IServiceProvider, object>(null, &Build);
+                codeGen
+                    .Ldnull()
+                    .Ldftn(buildMethod)
+                    .Newobj(_funcType.Constructors.FirstOrDefault(ct =>
+                        ct.Parameters.Count == 2 &&
+                        ct.Parameters[0].Equals(context.Configuration.WellKnownTypes.Object)));
+            }
 
             // Allow to save values from the parent context, pass own service provider, etc, etc
-            if (context.Configuration.TypeMappings.DeferredContentExecutorCustomization != null)
+            if (customization is not null)
             {
-
-                var customization = context.Configuration.TypeMappings.DeferredContentExecutorCustomization;
-                if (_deferredContentCustomizationTypeParameter != null)
-                    customization =
-                        customization.MakeGenericMethod(new[] { _deferredContentCustomizationTypeParameter });
                 codeGen
                     .Ldloc(context.ContextLocal)
                     .EmitCall(customization);
             }
 
-            return XamlILNodeEmitResult.Type(0, funcType);
+            return XamlILNodeEmitResult.Type(0, Type.GetClrType());
         }
 
-#nullable enable
+        private static bool IsFunctionPointerLike(IXamlType xamlType)
+            => xamlType.IsFunctionPointer // Cecil, SRE with .NET 8
+               || xamlType.FullName == "System.IntPtr"; // SRE with .NET < 8 or .NET Standard
 
         private sealed class XamlClosureInfo
         {

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -284,6 +284,14 @@ namespace XamlX.IL
             {
                 return System.ResolveType(Enum.GetUnderlyingType(Type));
             }
+
+            public bool IsFunctionPointer
+#if NET8_0_OR_GREATER
+                => Type.IsFunctionPointer;
+#else
+                => false; // represented as IntPtr before .NET 8
+#endif
+
             public override string ToString() => Type.ToString();
         }
 

--- a/src/XamlX/Transform/XamlLanguageTypeMappings.cs
+++ b/src/XamlX/Transform/XamlLanguageTypeMappings.cs
@@ -56,7 +56,14 @@ namespace XamlX.Transform
         /// </summary>
         public IXamlMethod InnerServiceProviderFactoryMethod { get; set; }
         /// <summary>
-        /// static Func&lt;IServiceProvider, object&gt; DeferredTransformationFactory(Func&lt;IServiceProvider, object&gt; builder, IServiceProvider provider);
+        /// Expected signature:
+        /// <code>
+        /// static *any-non-void* DeferredTransformationFactory(Func&lt;IServiceProvider, object&gt; builder, IServiceProvider provider);
+        /// </code>
+        /// Or:
+        /// <code>
+        /// static *any-non-void* DeferredTransformationFactory(delegate*&lt;IServiceProvider, object&gt;, IServiceProvider provider);
+        /// </code>
         /// </summary>
         public IXamlMethod DeferredContentExecutorCustomization { get; set; }
         public List<IXamlType> DeferredContentPropertyAttributes { get; set; } = new List<IXamlType>();

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -38,6 +38,7 @@ namespace XamlX.TypeSystem
         bool IsInterface { get; }
         IXamlType GetEnumUnderlyingType();
         IReadOnlyList<IXamlType> GenericParameters { get; }
+        bool IsFunctionPointer { get; }
         int GetHashCode();
     }
 
@@ -261,6 +262,7 @@ namespace XamlX.TypeSystem
         public bool IsInterface => false;
         public IXamlType GetEnumUnderlyingType() => throw new InvalidOperationException();
         public IReadOnlyList<IXamlType> GenericParameters => null;
+        public bool IsFunctionPointer => false;
 
         public bool IsAssignableFrom(IXamlType type) => type == this;
 

--- a/src/XamlX/XamlX.csproj
+++ b/src/XamlX/XamlX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/CecilNetstandardTests/CecilNetstandardTests.csproj
+++ b/tests/CecilNetstandardTests/CecilNetstandardTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net47;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net47;netstandard2.0</TargetFrameworks>
         <DefineConstants>CECIL;USE_NETSTANDARD_BUILD;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/tests/CecilTests/CecilTests.cs
+++ b/tests/CecilTests/CecilTests.cs
@@ -39,7 +39,7 @@ namespace XamlParserTests
             var m = f.FieldType.Methods.First(x => x.Name == "SomeMethod");
             Assert.Equal("System.String", m.ReturnType.FullName);
             Assert.Equal("System.String", m.Parameters[0].FullName);
-            Assert.Equal(0, f.FieldType.Methods.First(x => x.Name == "SomeMethod").Parameters[0].GenericArguments.Count);
+            Assert.Empty(f.FieldType.Methods.First(x => x.Name == "SomeMethod").Parameters[0].GenericArguments);
 
             var gf = f.FieldType.Fields.First(x => x.Name == "Field");
             Assert.Equal("System.String", gf.FieldType.FullName);

--- a/tests/CecilTests/CecilTests.csproj
+++ b/tests/CecilTests/CecilTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net47;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net47;netstandard2.0</TargetFrameworks>
         <DefineConstants>CECIL;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/tests/GuilabsParserTests/GuilabsParserTests.csproj
+++ b/tests/GuilabsParserTests/GuilabsParserTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net47</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net47</TargetFrameworks>
         <DefineConstants>GUILABS;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/tests/Tests.Common.props
+++ b/tests/Tests.Common.props
@@ -3,6 +3,7 @@
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
         <ProvideCommandLineArgs>true</ProvideCommandLineArgs>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/tests/Tests.Common.props
+++ b/tests/Tests.Common.props
@@ -6,16 +6,16 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-        <PackageReference Include="xunit" Version="2.4.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" Condition="$(TargetFramework) != 'netstandard2.0'" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" Condition="$(TargetFramework) != 'netstandard2.0'" />
     </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\..\src\XamlX.Runtime\XamlX.Runtime.csproj" />
         <ProjectReference Include="..\..\src\XamlX\XamlX.csproj" />
     </ItemGroup>
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <ItemGroup>
         <Content Include="$(MSBuildThisFileDirectory)\xunit.runner.json" Link="xunit.runner.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>

--- a/tests/XamlParserTests/DeferredContentTests.cs
+++ b/tests/XamlParserTests/DeferredContentTests.cs
@@ -69,13 +69,14 @@ namespace XamlParserTests
         }
 
         public static unsafe Func<IServiceProvider, object> FunctionPointerCustomizer(
-            delegate*<IServiceProvider, object> builder,
+            IntPtr builder,
             IServiceProvider parentServices)
         {
             var parentRoot = parentServices.GetService<ITestRootObjectProvider>().RootObject;
             var cb = parentServices.GetService<CallbackExtensionCallback>();
+            var typedBuilder = (delegate*<IServiceProvider, object>)builder;
 
-            return sp => builder(new DictionaryServiceProvider
+            return sp => typedBuilder(new DictionaryServiceProvider
             {
                 [typeof(ITestRootObjectProvider)] = new ConstantRootObjectProvider {RootObject = parentRoot},
                 [typeof(CallbackExtensionCallback)] = cb,

--- a/tests/XamlParserTests/XamlParserTests.csproj
+++ b/tests/XamlParserTests/XamlParserTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net47</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;net47</TargetFrameworks>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
 </Project>

--- a/tests/xunit.runner.json
+++ b/tests/xunit.runner.json
@@ -1,1 +1,6 @@
-{ "appDomain": "denied" }
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false,
+  "parallelizeTestCollections": false,
+  "parallelizeAssembly": false
+}


### PR DESCRIPTION
This PR extends the `DeferredContentExecutorCustomization` with two new capabilities:
 - It can return any other type than `Func<IServiceProvider, object>`.
 - It can accept a `delegate*<IServiceProvider, object>` builder parameter instead of a `Func<IServiceProvider, object>` one.
 
Both changes aim to reduce allocations for deferred content. See the upcoming Avalonia PR for details.

.NET 8 has been added as an extra target, because it now [handles function pointers](https://learn.microsoft.com/en-us/dotnet/core/compatibility/reflection/8.0/function-pointer-reflection) in `System.Reflection`, which requires targeted code.

Corresponding unit tests have been added.

~Note: *only the last commit in this PR* is relevant, the previous one comes from #106. I've built on that PR due to conflicts, and will rebase to have a clean diff when it gets merged.~ Edit: now rebased
