### PR TITLE
fix: Cecil IXamlType GenericArguments and GenericParameters behavior

### DIFF
--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -91,14 +91,14 @@ namespace XamlX.TypeSystem
             public IReadOnlyList<IXamlType> GenericArguments =>
                 _genericArguments ?? (_genericArguments = Reference is GenericInstanceType gi
                     ? gi.GenericArguments.Select(ga => TypeSystem.Resolve(ga)).ToList()
-                    : null);
+                    : Array.Empty<IXamlType>());
 
             private IReadOnlyList<IXamlType> _genericParameters;
 
             public IReadOnlyList<IXamlType> GenericParameters =>
                 _genericParameters ?? (_genericParameters = Reference is TypeDefinition td && td.HasGenericParameters
                     ? td.GenericParameters.Select(gp => TypeSystem.Resolve(gp)).ToList()
-                    : null);
+                    : Array.Empty<IXamlType>());
             
 
             protected IReadOnlyList<IXamlCustomAttribute> _attributes;

--- a/tests/CecilTests/CecilTests.cs
+++ b/tests/CecilTests/CecilTests.cs
@@ -39,6 +39,7 @@ namespace XamlParserTests
             var m = f.FieldType.Methods.First(x => x.Name == "SomeMethod");
             Assert.Equal("System.String", m.ReturnType.FullName);
             Assert.Equal("System.String", m.Parameters[0].FullName);
+            Assert.Equal(0, f.FieldType.Methods.First(x => x.Name == "SomeMethod").Parameters[0].GenericArguments.Count);
 
             var gf = f.FieldType.Fields.First(x => x.Name == "Field");
             Assert.Equal("System.String", gf.FieldType.FullName);
@@ -47,7 +48,6 @@ namespace XamlParserTests
             Assert.Equal("System.String", p.PropertyType.FullName);
             Assert.Equal("System.String", p.Getter.ReturnType.FullName);
             Assert.Equal("System.String", p.Setter.Parameters[0].FullName);
-
         }
 
         [Fact]


### PR DESCRIPTION
## Current behavior

### Cecil 
 GenericArguments and GenericParameters  return null when is not generic type

### Sre

 GenericArguments and GenericParameters  return empty IReadOnlyList<IXamlType> when is not generic type


## Expected behavior

### Cecil 
 GenericArguments and GenericParameters  return empty IReadOnlyList<IXamlType> when is not generic type

### Sre

 GenericArguments and GenericParameters  return empty IReadOnlyList<IXamlType> when is not generic type

