### PR TITLE
Correctly import type with generic type arguments.

### DIFF
--- a/src/XamlX.IL.Cecil/CecilEmitter.cs
+++ b/src/XamlX.IL.Cecil/CecilEmitter.cs
@@ -129,7 +129,7 @@ namespace XamlX.TypeSystem
                 => Emit(Instruction.Create(Dic[code], M.ImportReference(((CecilMethod) method).IlReference)));
 
             public IXamlILEmitter Emit(SreOpCode code, IXamlConstructor ctor)
-                => Emit(Instruction.Create(Dic[code], M.ImportReference(((CecilConstructor) ctor).IlReference)));
+                => Emit(Instruction.Create(Dic[code], ImportReference(((CecilConstructor) ctor).IlReference)));
 
             public IXamlILEmitter Emit(SreOpCode code, string arg)
                 => Emit(Instruction.Create(Dic[code], arg));
@@ -155,7 +155,18 @@ namespace XamlX.TypeSystem
             public IXamlILEmitter Emit(SreOpCode code, double arg)
                 => Emit(Instruction.Create(Dic[code], arg));
 
+            private MethodReference ImportReference(MethodReference r)
+            {
+                var rv = M.ImportReference(r);
 
+                if (r.DeclaringType is GenericInstanceType gi)
+                {
+                    for (var c = 0; c < gi.GenericArguments.Count; c++)
+                        gi.GenericArguments[c] = M.ImportReference(gi.GenericArguments[c]);
+                }
+
+                return rv;
+            }
             class CecilLocal : IXamlILLocal
             {
                 public VariableDefinition Variable { get; set; }


### PR DESCRIPTION
When `ModuleDefinition.ImportReference` is called, there is a check to see if the type being imported is in the current module, and if so to exit early:

https://github.com/jbevain/cecil/blob/56d4409b8a0165830565c6e3f96f41bead2c418b/Mono.Cecil/ModuleDefinition.cs#L856

However this does not handle the case where the type being imported is in the current module, but the generic type arguments aren't. We need to explicitly import those types into the current module.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/10856