### PR TITLE
Add missing Imports in the emitter

### DIFF
--- a/src/XamlX.IL.Cecil/CecilEmitter.cs
+++ b/src/XamlX.IL.Cecil/CecilEmitter.cs
@@ -28,6 +28,11 @@ namespace XamlX.TypeSystem
                         gi.GenericArguments[c] = Import(gi.GenericArguments[c]);
                 }
 
+                if (rv is not TypeSpecification and not GenericParameter && rv.DeclaringType is not null)
+                {
+                    rv.DeclaringType = Import(rv.DeclaringType);
+                }
+
                 return rv;
             }
 
@@ -45,7 +50,10 @@ namespace XamlX.TypeSystem
 
                 // Types derived from MethodSpecification don't allow setting the declaring type.
                 if (m is not MethodSpecification)
+                {
                     rv.DeclaringType = Import(m.DeclaringType);
+                    rv.ReturnType = Import(rv.ReturnType);
+                }
 
                 return rv;
             }


### PR DESCRIPTION
No unit tests, as we didn't have any reports (yet) related to these missed imports. 
Other than these, method arguments types _might_ need to be imported as well, but they are most likely to be imported somewhere else. 