### PR TITLE
Use less aggressive CecilTypeComparisonMode.SignatureOnlyLoose by default

### DIFF
--- a/src/XamlX.IL.Cecil/Comparers/MethodReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/MethodReferenceEqualityComparer.cs
@@ -64,7 +64,7 @@ public class MethodReferenceEqualityComparer : EqualityComparer<MethodReference>
 		}
 
 		var xResolved = comparisonMode == CecilTypeComparisonMode.Exact ? x.Resolve() : x as MethodDefinition;
-		var yResolved = comparisonMode == CecilTypeComparisonMode.Exact ? y.Resolve() : x as MethodDefinition;
+		var yResolved = comparisonMode == CecilTypeComparisonMode.Exact ? y.Resolve() : y as MethodDefinition;
 
 		if (xResolved != yResolved)
 			return false;

--- a/src/XamlX.IL.Cecil/Comparers/MethodReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/MethodReferenceEqualityComparer.cs
@@ -25,7 +25,7 @@ public class MethodReferenceEqualityComparer : EqualityComparer<MethodReference>
 		return GetHashCodeFor(obj);
 	}
 
-	public static bool AreEqual(MethodReference x, MethodReference y)
+	public static bool AreEqual(MethodReference x, MethodReference y, CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.SignatureOnlyLoose)
 	{
 		if (ReferenceEquals(x, y))
 			return true;
@@ -45,7 +45,7 @@ public class MethodReferenceEqualityComparer : EqualityComparer<MethodReference>
 		if (x.Name != y.Name)
 			return false;
 
-		if (!TypeReferenceEqualityComparer.AreEqual(x.DeclaringType, y.DeclaringType))
+		if (!TypeReferenceEqualityComparer.AreEqual(x.DeclaringType, y.DeclaringType, comparisonMode))
 			return false;
 
 		var xGeneric = x as GenericInstanceMethod;
@@ -59,12 +59,12 @@ public class MethodReferenceEqualityComparer : EqualityComparer<MethodReference>
 				return false;
 
 			for (int i = 0; i < xGeneric.GenericArguments.Count; i++)
-				if (!TypeReferenceEqualityComparer.AreEqual(xGeneric.GenericArguments[i], yGeneric.GenericArguments[i]))
+				if (!TypeReferenceEqualityComparer.AreEqual(xGeneric.GenericArguments[i], yGeneric.GenericArguments[i], comparisonMode))
 					return false;
 		}
 
-		var xResolved = x.Resolve();
-		var yResolved = y.Resolve();
+		var xResolved = comparisonMode == CecilTypeComparisonMode.Exact ? x.Resolve() : x as MethodDefinition;
+		var yResolved = comparisonMode == CecilTypeComparisonMode.Exact ? y.Resolve() : x as MethodDefinition;
 
 		if (xResolved != yResolved)
 			return false;
@@ -100,7 +100,7 @@ public class MethodReferenceEqualityComparer : EqualityComparer<MethodReference>
 					for (int i = 0; i < x.Parameters.Count; i++)
 					{
 						if (!TypeReferenceEqualityComparer.AreEqual(x.Parameters[i].ParameterType,
-							    y.Parameters[i].ParameterType))
+							    y.Parameters[i].ParameterType, comparisonMode))
 							return false;
 					}
 				}
@@ -119,7 +119,7 @@ public class MethodReferenceEqualityComparer : EqualityComparer<MethodReference>
 	}
 
 	public static bool AreSignaturesEqual(MethodReference x, MethodReference y,
-		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.Exact)
+		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.SignatureOnlyLoose)
 	{
 		if (x.HasThis != y.HasThis)
 			return false;

--- a/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
@@ -34,7 +34,7 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 	}
 
 	public static bool AreEqual(TypeReference a, TypeReference b,
-		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.Exact)
+		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.SignatureOnlyLoose)
 	{
 		if (ReferenceEquals(a, b))
 			return true;
@@ -141,12 +141,11 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 		if (!a.Name.Equals(b.Name) || !a.Namespace.Equals(b.Namespace))
 			return false;
 
-		var xDefinition = a.Resolve();
-		var yDefinition = b.Resolve();
-
-		// For loose signature the types could be in different assemblies, as long as the type names match we will consider them equal
-		if (comparisonMode == CecilTypeComparisonMode.SignatureOnlyLoose)
+		if (comparisonMode == CecilTypeComparisonMode.Exact)
 		{
+			var xDefinition = a.Resolve();
+			var yDefinition = b.Resolve();
+
 			if (xDefinition.Module.Name != yDefinition.Module.Name)
 				return false;
 
@@ -156,11 +155,11 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 			return xDefinition.FullName == yDefinition.FullName;
 		}
 
-		return xDefinition == yDefinition;
+		return true;
 	}
 
 	static bool AreEqual(GenericParameter a, GenericParameter b,
-		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.Exact)
+		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.SignatureOnlyLoose)
 	{
 		if (ReferenceEquals(a, b))
 			return true;
@@ -185,7 +184,7 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 	}
 
 	static bool AreEqual(GenericInstanceType a, GenericInstanceType b,
-		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.Exact)
+		CecilTypeComparisonMode comparisonMode = CecilTypeComparisonMode.SignatureOnlyLoose)
 	{
 		if (ReferenceEquals(a, b))
 			return true;


### PR DESCRIPTION
Regression from https://github.com/kekekeks/XamlX/pull/114

What I didn't pay attention, by default, TypeReferenceEqualityComparer was resolving all compared types. Which makes sense, when you want to be exact about comparison, but in XamlX we don't have these scenarios. Pretty much every type usage in XamlX can be defined in a random assembly, until full type name matches. 

This PR changes default mode to `SignatureOnlyLoose`. Also hides Resolve usage only under `Exact` mode.

Fixes https://github.com/AvaloniaUI/Avalonia/issues/15436

I was also thinking that we shouldn't really resolve all IXamlType types ahead. Especially for usages like XamlAttribute.Type, where it's enough to only have a TypeReference. But this change would be way too involving, so I will leave it for the future. 