### PR TITLE
Bring back CecilTypeCache

### DIFF
--- a/src/XamlX.IL.Cecil/CecilEvent.cs
+++ b/src/XamlX.IL.Cecil/CecilEvent.cs
@@ -25,13 +25,13 @@ namespace XamlX.TypeSystem
 
             public bool Equals(IXamlEventInfo other) =>
                 other is CecilEvent cf
-                && TypeReferenceEqualityComparer.AreEqual(Event.DeclaringType, cf.Event.DeclaringType)
+                && TypeReferenceEqualityComparer.AreEqual(Event.DeclaringType, cf.Event.DeclaringType, CecilTypeComparisonMode.Exact)
                 && cf.Event.FullName == Event.FullName;
 
             public override bool Equals(object other) => Equals(other as IXamlEventInfo); 
 
             public override int GetHashCode() =>
-                (TypeReferenceEqualityComparer.GetHashCodeFor(Event.DeclaringType), Event.FullName).GetHashCode();
+                (TypeReferenceEqualityComparer.GetHashCodeFor(Event.DeclaringType, CecilTypeComparisonMode.Exact), Event.FullName).GetHashCode();
 
             public override string ToString() => Event.ToString();
         }

--- a/src/XamlX.IL.Cecil/CecilField.cs
+++ b/src/XamlX.IL.Cecil/CecilField.cs
@@ -41,13 +41,13 @@ namespace XamlX.TypeSystem
 
             public bool Equals(IXamlField other) =>
                 other is CecilField cf
-                && TypeReferenceEqualityComparer.AreEqual(Field.DeclaringType, cf.Field.DeclaringType)
+                && TypeReferenceEqualityComparer.AreEqual(Field.DeclaringType, cf.Field.DeclaringType, CecilTypeComparisonMode.Exact)
                 && cf.Field.FullName == Field.FullName;
 
             public override bool Equals(object other) => Equals(other as IXamlField); 
 
             public override int GetHashCode() =>
-                (TypeReferenceEqualityComparer.GetHashCodeFor(Field.DeclaringType), Field.FullName).GetHashCode();
+                (TypeReferenceEqualityComparer.GetHashCodeFor(Field.DeclaringType, CecilTypeComparisonMode.Exact), Field.FullName).GetHashCode();
 
             public override string ToString() => Field.ToString();
         }

--- a/src/XamlX.IL.Cecil/CecilMethod.cs
+++ b/src/XamlX.IL.Cecil/CecilMethod.cs
@@ -79,12 +79,12 @@ namespace XamlX.TypeSystem
 
             public bool Equals(IXamlMethod other) =>
                 other is CecilMethod cm
-                && MethodReferenceEqualityComparer.AreEqual(Reference, cm.Reference);
+                && MethodReferenceEqualityComparer.AreEqual(Reference, cm.Reference, CecilTypeComparisonMode.Exact);
 
             public override bool Equals(object other) => Equals(other as IXamlMethod);
 
             public override int GetHashCode() 
-                => MethodReferenceEqualityComparer.GetHashCodeFor(Reference);
+                => MethodReferenceEqualityComparer.GetHashCodeFor(Reference, CecilTypeComparisonMode.Exact);
         }
         
         [DebuggerDisplay("{" + nameof(Reference) + "}")]
@@ -97,12 +97,12 @@ namespace XamlX.TypeSystem
 
             public bool Equals(IXamlConstructor other) =>
                 other is CecilConstructor cm
-                && MethodReferenceEqualityComparer.AreEqual(Reference, cm.Reference);
+                && MethodReferenceEqualityComparer.AreEqual(Reference, cm.Reference, CecilTypeComparisonMode.Exact);
 
             public override bool Equals(object other) => Equals(other as IXamlConstructor);
 
             public override int GetHashCode() 
-                => MethodReferenceEqualityComparer.GetHashCodeFor(Reference);
+                => MethodReferenceEqualityComparer.GetHashCodeFor(Reference, CecilTypeComparisonMode.Exact);
         }
     }
 }

--- a/src/XamlX.IL.Cecil/CecilProperty.cs
+++ b/src/XamlX.IL.Cecil/CecilProperty.cs
@@ -44,13 +44,13 @@ namespace XamlX.TypeSystem
 
             public bool Equals(IXamlProperty other) =>
                 other is CecilProperty cf
-                && TypeReferenceEqualityComparer.AreEqual(Property.DeclaringType, cf.Property.DeclaringType)
+                && TypeReferenceEqualityComparer.AreEqual(Property.DeclaringType, cf.Property.DeclaringType, CecilTypeComparisonMode.Exact)
                 && cf.Property.FullName == Property.FullName;
 
             public override bool Equals(object other) => Equals(other as IXamlProperty); 
 
             public override int GetHashCode() =>
-                (TypeReferenceEqualityComparer.GetHashCodeFor(Property.DeclaringType), Property.FullName).GetHashCode();
+                (TypeReferenceEqualityComparer.GetHashCodeFor(Property.DeclaringType, CecilTypeComparisonMode.Exact), Property.FullName).GetHashCode();
 
             public override string ToString() => Property.ToString();
         }

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -178,12 +178,12 @@ namespace XamlX.TypeSystem
             {
                 if (!(other is CecilType o))
                     return false;
-                return TypeReferenceEqualityComparer.AreEqual(Reference, o.Reference);
+                return TypeReferenceEqualityComparer.AreEqual(Reference, o.Reference, CecilTypeComparisonMode.Exact);
             }
 
             public override bool Equals(object other) => Equals(other as IXamlType);
 
-            public override int GetHashCode() => TypeReferenceEqualityComparer.GetHashCodeFor(Reference);
+            public override int GetHashCode() => TypeReferenceEqualityComparer.GetHashCodeFor(Reference, CecilTypeComparisonMode.Exact);
 
             public override string ToString() => Definition.ToString();
         }

--- a/src/XamlX.IL.Cecil/CecilTypeCache.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeCache.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+
+namespace XamlX.TypeSystem;
+
+internal class CecilTypeCache
+{
+    // Don't use comparer here. Reference based GetHashCode is expected for TypeReference.
+    // To avoid IXamlType duplicates we have second layer of TypeDefinition cache.
+    private readonly Dictionary<TypeReference, IXamlType> _typeReferenceCache = new();
+
+    private readonly Dictionary<TypeDefinition, DefinitionEntry> _definitions =
+        new();
+
+    private class DefinitionEntry
+    {
+        public Dictionary<MetadataType, List<CecilTypeSystem.CecilType>> References { get; } = new();
+    }
+
+    public IXamlType Resolve(CecilTypeResolveContext resolveContext, TypeReference reference)
+    {
+        if (reference.Name.Contains("RelativeSource"))
+        {
+            
+        }
+        
+        if (!_typeReferenceCache.TryGetValue(reference, out var rv))
+        {
+            TypeDefinition definition = null;
+            try
+            {
+                definition = reference.Resolve();
+            }
+            catch (AssemblyResolutionException)
+            {
+
+            }
+
+            if (definition != null)
+            {
+                rv = SecondLayerCache(resolveContext, reference, definition);
+            }
+            else
+            {
+                rv = new CecilTypeSystem.UnresolvedCecilType(reference);
+            }
+
+            _typeReferenceCache[reference] = rv;
+        }
+
+        return rv;
+    }
+
+    private CecilTypeSystem.CecilType SecondLayerCache(
+        CecilTypeResolveContext resolveContext,
+        TypeReference reference,
+        TypeDefinition definition)
+    {
+        var asm = resolveContext.TypeSystem.FindAsm(definition.Module.Assembly);
+
+        // `_typeReferenceCache.TryGetValue` might result in duplicates, as the same Type can have different resolving modules.
+        if (!_definitions.TryGetValue(definition, out var dentry))
+            _definitions[definition] = dentry = new DefinitionEntry();
+
+        // Per single TypeDefinition, there could be multiple TypeReference with different signature and different types.
+        var metadataType = reference.MetadataType;
+        if (!dentry.References.TryGetValue(metadataType, out var rlist))
+            dentry.References[metadataType] = rlist = new List<CecilTypeSystem.CecilType>();
+
+        // If we previously had cached TypeDefinition+TypeReference with the same signature - return existing. 
+        var found = rlist.FirstOrDefault(t =>
+            TypeReferenceEqualityComparer.AreEqual(t.Reference, reference, CecilTypeComparisonMode.SignatureOnlyLoose));
+        if (found != null)
+            return found;
+
+        // Otherwise create and cache a new one.
+        var cecilType = new CecilTypeSystem.CecilType(resolveContext, asm, definition, reference);
+        rlist.Add(cecilType);
+
+        return cecilType;
+    }
+}

--- a/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
@@ -209,6 +209,8 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 		const int optionalModifierMultiplier = 47;
 		const int pinnedMultiplier = 53;
 		const int sentinelMultiplier = 59;
+		const int moduleMultiplier = 61;
+		const int assemblyMultiplier = 67;
 
 		var metadataType = obj.MetadataType;
 
@@ -290,6 +292,18 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 			throw new NotImplementedException("We currently don't handle function pointer types.");
 		}
 
-		return obj.Namespace.GetHashCode() * hashCodeMultiplier + obj.FullName.GetHashCode();
+		if (comparisonMode == CecilTypeComparisonMode.Exact)
+		{
+			var def = obj.Resolve();
+			return def.Module.Name.GetHashCode() * moduleMultiplier
+			       + def.Module.Assembly.Name.Name.GetHashCode() * assemblyMultiplier
+			       + obj.Namespace.GetHashCode() * hashCodeMultiplier
+			       + obj.FullName.GetHashCode();
+		}
+		else
+		{
+			return obj.Namespace.GetHashCode() * hashCodeMultiplier
+			       + obj.FullName.GetHashCode();
+		}
 	}
 }

--- a/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
@@ -135,11 +135,11 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 		if (!a.Name.Equals(b.Name) || !a.Namespace.Equals(b.Namespace))
 			return false;
 
-		if (comparisonMode == CecilTypeComparisonMode.Exact)
-		{
-			var xDefinition = a.Resolve();
-			var yDefinition = b.Resolve();
+		var xDefinition = comparisonMode == CecilTypeComparisonMode.Exact ? a.Resolve() : a as TypeDefinition;
+		var yDefinition = comparisonMode == CecilTypeComparisonMode.Exact ? b.Resolve() : b as TypeDefinition;
 
+		if (xDefinition is not null && yDefinition is not null)
+		{
 			if (xDefinition.Module.Name != yDefinition.Module.Name)
 				return false;
 
@@ -292,9 +292,10 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 			throw new NotImplementedException("We currently don't handle function pointer types.");
 		}
 
-		if (comparisonMode == CecilTypeComparisonMode.Exact)
+		var def = comparisonMode == CecilTypeComparisonMode.Exact ? obj.Resolve() : obj as TypeDefinition;
+
+		if (def is not null)
 		{
-			var def = obj.Resolve();
 			return def.Module.Name.GetHashCode() * moduleMultiplier
 			       + def.Module.Assembly.Name.Name.GetHashCode() * assemblyMultiplier
 			       + obj.Namespace.GetHashCode() * hashCodeMultiplier

--- a/src/XamlX.IL.Cecil/Resolvers/CecilTypeResolveContext.cs
+++ b/src/XamlX.IL.Cecil/Resolvers/CecilTypeResolveContext.cs
@@ -21,7 +21,11 @@ internal class CecilTypeResolveContext
     {
         TypeSystem = typeSystem;
         _genericTypeResolver = genericTypeResolver;
-        _typeReferenceCache = typeReferenceCache ?? new(new TypeReferenceEqualityComparer());
+
+        // Don't use CecilTypeComparisonMode.Exact on type cache, as we don't want to Resolve all types for that.
+        // We don't mind some duplicates, if comes. 
+        _typeReferenceCache = typeReferenceCache ?? new(new TypeReferenceEqualityComparer(
+            CecilTypeComparisonMode.SignatureOnlyLoose));
     }
 
     public CecilTypeResolveContext Nested(TypeReference typeReference)

--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -288,7 +288,7 @@ namespace XamlX.IL.Emitters
             }
 
             public bool Equals(SettersCacheKey other)
-                => ParentType == other.ParentType
+                => ParentType.Equals(other.ParentType)
                    && AreListEqual(ValueTypes, other.ValueTypes)
                    && AreListEqual(Setters, other.Setters);
 

--- a/src/XamlX/IL/XamlIlCompiler.cs
+++ b/src/XamlX/IL/XamlIlCompiler.cs
@@ -98,7 +98,7 @@ namespace XamlX.IL
             if (rootInstance is XamlAstNewClrObjectNode newObj)
             {
                 needContextLocal = newObj.Arguments.Count == 1 &&
-                                   newObj.Arguments[0].Type.GetClrType() == _configuration.TypeMappings.ServiceProvider;
+                                   newObj.Arguments[0].Type.GetClrType().Equals(_configuration.TypeMappings.ServiceProvider);
 
                 var ctorParams = newObj.Constructor.Parameters.Select(c => c.GetFullName());
                 var args = newObj.Arguments.Select(a => a.Type.GetClrType().GetFullName());

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -173,7 +173,7 @@ namespace XamlX.Transform
             if (custom != null)
                 yield return custom;
             foreach(var attr in type.CustomAttributes)
-                if (attr.Type == attributeType)
+                if (attr.Type.Equals(attributeType))
                     yield return attr;
         }
         

--- a/src/XamlX/Transform/Transformers/ObsoleteWarningsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ObsoleteWarningsTransformer.cs
@@ -48,7 +48,7 @@ public
 
         IXamlCustomAttribute? FindAttr(IEnumerable<IXamlCustomAttribute> attributes)
         {
-            return attributes.FirstOrDefault(a => a.Type == obsoleteAttributeType);
+            return attributes.FirstOrDefault(a => a.Type.Equals(obsoleteAttributeType));
         }
 
         void ReportObsolete(string member, IXamlCustomAttribute attribute)


### PR DESCRIPTION
Again.

Two main changes:
1. Make TypeReferenceEqualityComparer and MethodReferenceEqualityComparer to have **required** CecilTypeComparisonMode parameters. So it will be harder to forget or misuse API by accident.
2. Bring back CecilTypeCache with two layers of caching. + added comments on CecilTypeCache to describe how it works.

Minor:
- Use .Equals instead of '==' where possible in XamlX repo. Ideally, we shouldn't rely on reference equals at all. It will require adding XamlTypeBase or something.
- Make TypeReferenceEqualityComparer.GetHashCode to actually respect Module/Assembly. I don't know why it wasn't there before in the cecil code. 

Fixes https://github.com/AvaloniaUI/Avalonia/issues/15436

Tested with:
- XamlX tests
- Avalonia tests
- ControlCatalog
- Original issue repro

Can't wait for another regression. And we should enable Cecil tests in Avalonia repo as well.