### PR TITLE
Handle custom attributes from attached property setter

### DIFF
--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -72,8 +72,14 @@ namespace XamlX.Ast
             }
         }
 
-        public XamlAstClrProperty(IXamlLineInfo lineInfo, string name, IXamlType declaringType,
-            IXamlMethod? getter, IEnumerable<IXamlPropertySetter>? setters) : base(lineInfo)
+        public XamlAstClrProperty(
+            IXamlLineInfo lineInfo,
+            string name,
+            IXamlType declaringType,
+            IXamlMethod? getter,
+            IEnumerable<IXamlPropertySetter>? setters,
+            IEnumerable<IXamlCustomAttribute>? customAttributes)
+            : base(lineInfo)
         {
             Name = name;
             DeclaringType = declaringType;
@@ -83,13 +89,30 @@ namespace XamlX.Ast
             IsFamily = getter?.IsFamily == true;
             if (setters != null)
                 Setters.AddRange(setters);
+            if (customAttributes is not null)
+                CustomAttributes.AddRange(customAttributes);
         }
 
-        public XamlAstClrProperty(IXamlLineInfo lineInfo, string name, IXamlType declaringType,
-            IXamlMethod? getter, params IXamlMethod?[] setters) : this(lineInfo, name, declaringType,
-            getter, setters.Where(x=> !(x is null)).Select(x => new XamlDirectCallPropertySetter(x!)))
+        public XamlAstClrProperty(
+            IXamlLineInfo lineInfo,
+            string name,
+            IXamlType declaringType,
+            IXamlMethod? getter,
+            IEnumerable<IXamlMethod?>? setters,
+            IEnumerable<IXamlCustomAttribute>? customAttributes)
+            : this(
+                lineInfo,
+                name,
+                declaringType,
+                getter,
+                setters?.Where(x => x is not null).Select(x => new XamlDirectCallPropertySetter(x!)),
+                customAttributes)
         {
+        }
 
+        public XamlAstClrProperty(IXamlLineInfo lineInfo, string name, IXamlType declaringType, IXamlMethod? getter)
+            : this(lineInfo, name, declaringType, getter, (IEnumerable<IXamlPropertySetter>?)null, null)
+        {
         }
 
         public override string ToString() => DeclaringType.GetFqn() + "." + Name;

--- a/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
@@ -40,7 +40,7 @@ namespace XamlX.Transform.Transformers
                                                                                     && p.Add != null);
                     if (clrEvent != null)
                         return new XamlAstClrProperty(prop,
-                            prop.Name, clrEvent.Add!.DeclaringType, null, clrEvent.Add);
+                            prop.Name, clrEvent.Add!.DeclaringType, null, [clrEvent.Add], null);
                 }
 
                 // Look for attached properties on declaring type
@@ -68,16 +68,19 @@ namespace XamlX.Transform.Transformers
                 }
 
                 if (setter != null || getter != null)
-                    return new XamlAstClrProperty(prop, prop.Name, declaringType, getter, setter);
+                {
+                    var customAttributes = setter?.GetParameterInfo(1).CustomAttributes;
+                    return new XamlAstClrProperty(prop, prop.Name, declaringType, getter, [setter], customAttributes);
+                }
 
                 if (adder != null)
-                    return new XamlAstClrProperty(prop, prop.Name, declaringType, null, adder);
+                    return new XamlAstClrProperty(prop, prop.Name, declaringType, null, [adder], null);
 
                 return context.ReportTransformError(
                     $"Unable to resolve suitable regular or attached property {prop.Name} on type {declaringType.GetFqn()}",
                     node, FakeProperty());
 
-                XamlAstClrProperty FakeProperty() => new(prop, prop.Name, XamlPseudoType.Unknown, null, Array.Empty<IXamlMethod>());
+                XamlAstClrProperty FakeProperty() => new(prop, prop.Name, XamlPseudoType.Unknown, null);
             }
 
             return node;

--- a/src/XamlX/Transform/Transformers/ResolveContentPropertyTransformer.cs
+++ b/src/XamlX/Transform/Transformers/ResolveContentPropertyTransformer.cs
@@ -56,7 +56,7 @@ namespace XamlX.Transform.Transformers
                                         adders.Select(a => new XamlDirectCallPropertySetter(a)
                                         {
                                             BinderParameters = {AllowMultiple = true}
-                                        })),
+                                        }), null),
                                     Array.Empty<IXamlAstValueNode>(),
                                     false);
                             }

--- a/tests/XamlParserTests/DynamicSettersTests.cs
+++ b/tests/XamlParserTests/DynamicSettersTests.cs
@@ -495,7 +495,7 @@ namespace XamlParserTests
                 XamlAstClrProperty original,
                 IXamlMethod getSpecialHandlerMethod,
                 IXamlMethod handleMethod)
-                : base(original, original.Name, original.DeclaringType, original.Getter, original.Setters)
+                : base(original, original.Name, original.DeclaringType, original.Getter, original.Setters, null)
                 => Setters.Add(new SpecialHandlerPropertySetter(
                     handleMethod.DeclaringType,
                     handleMethod.Parameters[0],


### PR DESCRIPTION
This PR passes the custom attributes from an attached property setter to `XamlAstClrProperty`.
This is necessary to make `[AssignBinding]` work on attached properties in Avalonia.

The custom attributes are taken from the setter's second parameter, e.g.:
```csharp
public static void SetAttachedBinding(Control obj, [AssignBinding] IBinding? value)
```

