### PR TITLE
Get custom attributes from attached property getter

### DIFF
--- a/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/PropertyReferenceResolver.cs
@@ -69,7 +69,7 @@ namespace XamlX.Transform.Transformers
 
                 if (setter != null || getter != null)
                 {
-                    var customAttributes = setter?.GetParameterInfo(1).CustomAttributes;
+                    var customAttributes = getter?.CustomAttributes;
                     return new XamlAstClrProperty(prop, prop.Name, declaringType, getter, [setter], customAttributes);
                 }
 


### PR DESCRIPTION
Follow-up to #126.
The attributes for an attached property are now fetched from the getter, instead of the setter's argument.
This matches WPF and Silverlight.