### PR TITLE
Update .NET to 10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
     <PropertyGroup>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>14.0</LangVersion>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>$(WarningsAsErrors);nullable</WarningsAsErrors>
     </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,11 @@ jobs:
           packageType: runtime
           version: 8.0.x
 
+      - script: |
+          sudo apt-get update
+          sudo apt-get install -y mono-complete
+        displayName: 'Install Mono'
+
       - task: CmdLine@2
         displayName: 'Run Tests'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,15 +4,16 @@ jobs:
       vmImage: 'ubuntu-20.04'
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET SDK 8.0.203'
+        displayName: 'Use .NET SDK 10.0.100'
         inputs:
-          version: 8.0.203
+          version: 10.0.100-rc.2.25502.107
+          includePreviewVersions: true
 
       - task: UseDotNet@2
-        displayName: 'Use .NET Runtime 6.0'
+        displayName: 'Use .NET Runtime 8.0'
         inputs:
           packageType: runtime
-          version: 6.0.x
+          version: 8.0.x
 
       - task: CmdLine@2
         displayName: 'Run Tests'
@@ -38,15 +39,16 @@ jobs:
       SolutionDir: '$(Build.SourcesDirectory)'
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET SDK 8.0.203'
+        displayName: 'Use .NET SDK 10.0.100'
         inputs:
-          version: 8.0.203
+          version: 10.0.100-rc.2.25502.107
+          includePreviewVersions: true
           
       - task: UseDotNet@2
-        displayName: 'Use .NET Runtime 6.0'
+        displayName: 'Use .NET Runtime 8.0'
         inputs:
           packageType: runtime
-          version: 6.0.x
+          version: 8.0.x
 
       - task: CmdLine@2
         displayName: 'Run Tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
   - job: Linux
     pool:
-      vmImage: 'ubuntu-20.04'
+      vmImage: 'ubuntu-24.04'
     steps:
       - task: UseDotNet@2
         displayName: 'Use .NET SDK 10.0.100'
@@ -34,7 +34,7 @@ jobs:
 
   - job: Windows
     pool:
-      vmImage: 'windows-2022'
+      vmImage: 'windows-2025'
     variables:
       SolutionDir: '$(Build.SourcesDirectory)'
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,8 @@ jobs:
             mono --version
             dotnet --info
             dotnet build
+            dotnet test -f net10.0 --logger "trx" --results-directory artifacts/test-results
             dotnet test -f net8.0 --logger "trx" --results-directory artifacts/test-results
-            dotnet test -f net6.0 --logger "trx" --results-directory artifacts/test-results
             dotnet test -f net47  --logger "trx" --results-directory artifacts/test-results
       - task: PublishTestResults@2
         inputs:
@@ -54,8 +54,8 @@ jobs:
           script: |
             dotnet --info
             dotnet build
+            dotnet test -f net10.0 --logger "trx" --results-directory artifacts/test-results
             dotnet test -f net8.0 --logger "trx" --results-directory artifacts/test-results
-            dotnet test -f net6.0 --logger "trx" --results-directory artifacts/test-results
             dotnet test -f net47  --logger "trx" --results-directory artifacts/test-results
 
       - task: PublishTestResults@2

--- a/src/BenchmarksCompiler/BenchmarksCompiler.csproj
+++ b/src/BenchmarksCompiler/BenchmarksCompiler.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/XamlX.IL.Cecil/CecilCustomAttribute.cs
+++ b/src/XamlX.IL.Cecil/CecilCustomAttribute.cs
@@ -52,9 +52,9 @@ namespace XamlX.TypeSystem
                         {
                             properties.Add(prop.Name, ConvertValue(prop.Argument.Value));
                         }
-                        foreach (var field in Data.Fields)
+                        foreach (var @field in Data.Fields)
                         {
-                            properties.Add(field.Name, ConvertValue(field.Argument.Value));
+                            properties.Add(@field.Name, ConvertValue(@field.Argument.Value));
                         }
                         _properties = properties;
                     }

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
@@ -24,7 +25,8 @@ namespace XamlX.TypeSystem
             {
                 
             }
-            
+
+            [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
             public CecilType(CecilTypeResolveContext parentTypeResolveContext, CecilAssembly? assembly, TypeDefinition definition,
                 TypeReference reference)
             {

--- a/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
@@ -142,6 +143,7 @@ namespace XamlX.TypeSystem
                 return new CecilTypeBuilder(_builderTypeResolveContext, (CecilAssembly?)Assembly, td);
             }
 
+            [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
             public IXamlTypeBuilder<IXamlILEmitter> DefineDelegateSubType(string name, XamlVisibility visibility,
                 IXamlType returnType, IEnumerable<IXamlType> parameterTypes)
             {

--- a/src/XamlX.IL.Cecil/XamlX.IL.Cecil.csproj
+++ b/src/XamlX.IL.Cecil/XamlX.IL.Cecil.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
   <PropertyGroup>

--- a/src/XamlX.Parser.GuiLabs/XamlX.Parser.GuiLabs.csproj
+++ b/src/XamlX.Parser.GuiLabs/XamlX.Parser.GuiLabs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>XamlX</RootNamespace>
   </PropertyGroup>
   <ItemGroup>

--- a/src/XamlX.Runtime/XamlX.Runtime.csproj
+++ b/src/XamlX.Runtime/XamlX.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using XamlX.Emit;
 using XamlX.IL;
@@ -694,6 +695,7 @@ namespace XamlX.Ast
         public IXamlAstValueNode Value { get; set; }
         public IXamlAstTypeReference Type { get; }
         
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public XamlDeferredContentNode(IXamlAstValueNode value,
             IXamlType? deferredContentCustomizationTypeParameter,
             TransformerConfiguration config) : base(value)

--- a/src/XamlX/Ast/Intrinsics.cs
+++ b/src/XamlX/Ast/Intrinsics.cs
@@ -131,7 +131,7 @@ namespace XamlX.Ast
 
         public IXamlAstTypeReference Type => new XamlAstClrTypeReference(this, ResolveMember(false) switch
         {
-            IXamlField field => field.FieldType,
+            IXamlField @field => @field.FieldType,
             IXamlProperty { Getter: not null } prop => prop.Getter.ReturnType,
             _ => XamlPseudoType.Unknown
         }, false);

--- a/src/XamlX/Diagnostics/TrimmingMessages.cs
+++ b/src/XamlX/Diagnostics/TrimmingMessages.cs
@@ -18,4 +18,7 @@ internal static class TrimmingMessages
     
     public const string DynamicXamlReference =
         "x:Class directive type and XAML dependencies are referenced dynamically and might be trimmed.";
+
+    public const string TypeInCoreAssembly =
+        "The types reside in the core assembly and will always be found.";
 }

--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using XamlX.Ast;
 using XamlX.Emit;
@@ -160,6 +161,7 @@ namespace XamlX.IL.Emitters
             return method;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         private static void EmitDynamicSetterMethod(
             IReadOnlyList<IXamlType> valueTypes,
             IReadOnlyList<IXamlPropertySetter> setters,

--- a/src/XamlX/IL/NamespaceInfoProvider.cs
+++ b/src/XamlX/IL/NamespaceInfoProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection.Emit;
 using XamlX.Ast;
 using XamlX.Transform;
@@ -53,6 +54,7 @@ namespace XamlX.IL
 
             var createNamespaceInfoMethod = EmitCreateNamespaceInfoMethod();
 
+            [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
             IXamlMethod EmitCreateNamespacesMethod()
             {
                 // C#: private static IReadOnlyDictionary<string, IReadOnlyList<string>> CreateNamespaces()

--- a/src/XamlX/IL/RuntimeContext.cs
+++ b/src/XamlX/IL/RuntimeContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection.Emit;
 using XamlX.Emit;
@@ -14,6 +15,7 @@ namespace XamlX.IL
 #endif
     class RuntimeContext : XamlRuntimeContext<IXamlILEmitter, XamlILNodeEmitResult>
     {
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public RuntimeContext(IXamlType definition, IXamlType constructedType,
             XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult> mappings,
             string? baseUri, List<IXamlField>? staticProviders)
@@ -85,7 +87,8 @@ namespace XamlX.IL
 
         public const int BaseUriArg = 0;
         public const int StaticProvidersArg = 1;
-        
+
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         private XamlILContextDefinition(IXamlTypeBuilder<IXamlILEmitter> parentBuilder,
             IXamlTypeSystem typeSystem, XamlLanguageTypeMappings mappings,
             XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult> emitMappings)
@@ -408,6 +411,7 @@ namespace XamlX.IL
                 cb();
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         private void EmitPushPopParent(IXamlTypeBuilder<IXamlILEmitter> builder, IXamlTypeSystem ts)
         {
             Debug.Assert(ParentListField is not null);
@@ -500,6 +504,7 @@ namespace XamlX.IL
             PropertyStub("Instance");
             PropertyStub("PropertyDescriptor");
 
+            [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
             void MethodStub(string name)
             {
                 var original = tdc.GetMethod(m => m.Name == name);
@@ -517,7 +522,8 @@ namespace XamlX.IL
 
             return mappings.TypeDescriptorContext;
         }
-        
+
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         (IXamlType type, IXamlConstructor ctor, Action createCallback) EmitParentEnumerable(IXamlTypeSystem typeSystem, IXamlTypeBuilder<IXamlILEmitter> parentBuilder,
             XamlLanguageTypeMappings mappings)
         {

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -234,6 +234,7 @@ namespace XamlX.IL
                         BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
                     .Select(c => new SreConstructor(System, c)).ToList();
 
+            [SuppressMessage("Trimming", "IL2111", Justification = "An error will be reported if the type cannot be bound.")]
             public IReadOnlyList<IXamlType> Interfaces =>
                 _interfaces ??= Type.GetInterfaces().Select(System.ResolveType).ToList()!;
 
@@ -244,6 +245,7 @@ namespace XamlX.IL
 
             public bool IsInterface => Type.IsInterface;
 
+            [SuppressMessage("Trimming", "IL2111", Justification = "An error will be reported if the type cannot be bound.")]
             public IReadOnlyList<IXamlType> GenericArguments
             {
                 get
@@ -256,6 +258,7 @@ namespace XamlX.IL
                 }
             }
 
+            [SuppressMessage("Trimming", "IL2111", Justification = "An error will be reported if the type cannot be bound.")]
             public IReadOnlyList<IXamlType> GenericParameters =>
                 _genericParameters ??= Type.GetTypeInfo().GenericTypeParameters.Select(System.ResolveType).ToList()!;
 
@@ -326,6 +329,7 @@ namespace XamlX.IL
         {
             private readonly CustomAttributeData _data;
 
+            [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = TrimmingMessages.CanBeSafelyTrimmed)]
             public SreCustomAttribute(SreTypeSystem system, CustomAttributeData data, IXamlType type)
             {
                 Type = type;
@@ -442,6 +446,7 @@ namespace XamlX.IL
 
             public bool IsGenericMethodDefinition => Method.IsGenericMethodDefinition;
 
+            [SuppressMessage("Trimming", "IL2111", Justification = "An error will be reported if the type cannot be bound.")]
             public IReadOnlyList<IXamlType> GenericParameters => _genericParameters ??=
                 Method.ContainsGenericParameters
                     ? Method.GetGenericArguments()
@@ -450,6 +455,7 @@ namespace XamlX.IL
                             .ToArray()
                     : Array.Empty<IXamlType>();
 
+            [SuppressMessage("Trimming", "IL2111", Justification = "An error will be reported if the type cannot be bound.")]
             public IReadOnlyList<IXamlType> GenericArguments => _genericArguments ??=
                 !Method.ContainsGenericParameters
                     ? Method.GetGenericArguments()

--- a/src/XamlX/IL/XamlILEmitterExtensions.cs
+++ b/src/XamlX/IL/XamlILEmitterExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection.Emit;
 using System.Text;
@@ -42,6 +43,7 @@ namespace XamlX.IL
             return emitter;
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = "Only used for debugging.")]
         public static IXamlILEmitter DebugHatch(this IXamlILEmitter emitter, string message)
         {
 #if DEBUG
@@ -176,6 +178,7 @@ namespace XamlX.IL
         public static IXamlILEmitter Ldtoken(this IXamlILEmitter emitter, IXamlMethod method)
             => emitter.Emit(OpCodes.Ldtoken, method);
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public static IXamlILEmitter Ldtype(this IXamlILEmitter emitter, IXamlType type)
         {
             var conv = emitter.TypeSystem.GetType("System.Type")
@@ -183,6 +186,7 @@ namespace XamlX.IL
             return emitter.Ldtoken(type).EmitCall(conv);
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public static IXamlILEmitter LdMethodInfo(this IXamlILEmitter emitter, IXamlMethod method)
         {
             var conv = emitter.TypeSystem.GetType("System.Reflection.MethodInfo")

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -229,6 +229,7 @@ namespace XamlX.Transform
         public IXamlType Delegate { get; }
         public IXamlType ObsoleteAttribute { get; }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public XamlTypeWellKnownTypes(IXamlTypeSystem typeSystem)
         {
             Void = typeSystem.GetType("System.Void");

--- a/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using XamlX.Ast;
 using XamlX.TypeSystem;
@@ -37,6 +38,7 @@ namespace XamlX.Transform.Transformers
                 return ResolveTypeCore(context, xmlns, name, isMarkupExtension, typeArguments, lineInfo);
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = "A compilation error will be reported if the type is not found.")]
         static XamlAstClrTypeReference ResolveTypeCore(AstTransformationContext context,
             string? xmlns, string name, bool isMarkupExtension, List<XamlAstXmlTypeReference>? typeArguments, IXamlLineInfo lineInfo)
         {

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using XamlX.Ast;
 using XamlX.TypeSystem;
 
@@ -8,6 +9,7 @@ namespace XamlX.Transform.Transformers
 #endif
     class XamlIntrinsicsTransformer : IXamlAstTransformer
     {
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public IXamlAstNode Transform(AstTransformationContext context, IXamlAstNode node)
         {
             if (node is XamlAstObjectNode ni 

--- a/src/XamlX/Transform/XamlLanguageTypeMappings.cs
+++ b/src/XamlX/Transform/XamlLanguageTypeMappings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using XamlX.TypeSystem;
 
 namespace XamlX.Transform
@@ -9,13 +10,11 @@ namespace XamlX.Transform
     class XamlLanguageTypeMappings
     {
         public XamlLanguageTypeMappings(IXamlTypeSystem typeSystem)
+            : this(typeSystem, useDefault: true)
         {
-            ServiceProvider = typeSystem.GetType("System.IServiceProvider");
-            TypeDescriptorContext = typeSystem.GetType("System.ComponentModel.ITypeDescriptorContext");
-            SupportInitialize = typeSystem.GetType("System.ComponentModel.ISupportInitialize");
-            TypeConverterAttributes.Add(typeSystem.GetType("System.ComponentModel.TypeConverterAttribute"));
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public XamlLanguageTypeMappings(IXamlTypeSystem typeSystem, bool useDefault)
         {
             if (useDefault)

--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -195,6 +195,7 @@ namespace XamlX.Transform
             return TryConvertValue(context, node, customAttributes, type, null, out rv);
         }
 
+        [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "The method can return null if the type is not found")]
         public static IXamlType? TryGetTypeConverterFromCustomAttribute(
             TransformerConfiguration cfg,
             IXamlCustomAttribute? attribute)

--- a/src/XamlX/XamlX.csproj
+++ b/src/XamlX/XamlX.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/tests/CecilNetstandardTests/CecilNetstandardTests.csproj
+++ b/tests/CecilNetstandardTests/CecilNetstandardTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net47;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;net47;netstandard2.0</TargetFrameworks>
         <DefineConstants>CECIL;USE_NETSTANDARD_BUILD;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/tests/CecilTests/CecilTests.csproj
+++ b/tests/CecilTests/CecilTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net47;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;net47;netstandard2.0</TargetFrameworks>
         <DefineConstants>CECIL;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/tests/GuilabsParserTests/GuilabsParserTests.csproj
+++ b/tests/GuilabsParserTests/GuilabsParserTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net47</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;net47</TargetFrameworks>
         <DefineConstants>GUILABS;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/tests/TypeSystemTest/TypeSystemTest.csproj
+++ b/tests/TypeSystemTest/TypeSystemTest.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;net47;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0;net47;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/XamlParserTests/XamlParserTests.csproj
+++ b/tests/XamlParserTests/XamlParserTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net8.0;net47</TargetFrameworks>
+        <TargetFrameworks>net10.0;net8.0;net47</TargetFrameworks>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)\..\Tests.Common.props" />
 </Project>


### PR DESCRIPTION
This PR updates XamlX to use .NET 10 and C# 14:
 - Some variables named `field` have been renamed.
 - Additional trimming warnings introduced in .NET 10 have been suppressed where appropriate.