### PR TITLE
Fix `x:Static` not searching base classes for fields.

### DIFF
--- a/src/XamlX/Ast/Intrinsics.cs
+++ b/src/XamlX/Ast/Intrinsics.cs
@@ -113,7 +113,7 @@ namespace XamlX.Ast
         internal IXamlMember? ResolveMember(bool throwOnUnknown)
         {
             var type = TargetType?.GetClrType();
-            var member = type?.Fields.FirstOrDefault(f => f.IsPublic && f.IsStatic && f.Name == Member) ??
+            var member = type?.GetAllFields().FirstOrDefault(f => f.IsPublic && f.IsStatic && f.Name == Member) ??
                    (IXamlMember?)type?.GetAllProperties().FirstOrDefault(p =>
                        p.Name == Member && p.Getter is { IsPublic: true, IsStatic: true });
 

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -21,6 +21,8 @@ namespace XamlParserTests
         public const double DoubleConstant = 3;
     }
 
+    public class IntrinsicsTestsDerivedClass : IntrinsicsTestsClass;
+
     public class IntrinsicsListTestsClass
     {
         internal int AddInt32CallCount;
@@ -93,6 +95,8 @@ namespace XamlParserTests
          InlineData(100, "IntrinsicsTestsClass.IntConstant"),
          InlineData(2f, "IntrinsicsTestsClass.FloatConstant"),
          InlineData(3d, "IntrinsicsTestsClass.DoubleConstant"),
+         InlineData("StaticPropValue", "IntrinsicsTestsDerivedClass.StaticProp"),
+         InlineData("StaticFieldValue", "IntrinsicsTestsDerivedClass.StaticField"),
         ]
         public void Static_Extension_Resolves_Values(object expected, string r)
         {


### PR DESCRIPTION
Although `x:Static` searched base classes for properties, it did not for fields - so if one referenced a field such as e.g. `Button.NameProperty` it would not be found. The same works for properties, and the same works in WPF so I think it's a bug.