### PR TITLE
Add inline generic parsing and nullable `?` notation for x:Type/x:Static

### DIFF
--- a/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
+++ b/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
@@ -35,34 +35,37 @@ namespace XamlX.Parsers
             for (var c = 0; c < s.Length; c++)
             {
                 var ch = s[c];
-                if (ch == ',')
+                switch (ch)
                 {
-                    stack.Peek().Children.Add(current = new Node());
-                }
-                else if (ch == ')')
-                {
-                    current = stack.Pop();
-                    if (stack.Count == 0)
-                        throw new ParseException("Unmatched ')'", c);
-                }
-                else if (afterClosing)
-                {
-                    if (char.IsWhiteSpace(ch))
-                        continue;
+                    case ',':
+                        stack.Peek().Children.Add(current = new Node());
+                        break;
+                    case ')':
+                    {
+                        current = stack.Pop();
+                        if (stack.Count == 0)
+                            throw new ParseException("Unmatched ')'", c);
+                        // current.Value += $"`{current.Children.Count}";
+                        break;
+                    }
+                    case { } when afterClosing:
+                    {
+                        if (char.IsWhiteSpace(ch))
+                            continue;
 
-                    if (ch is not '?')
-                        throw new ParseException("Invalid character after ')'", c);
+                        if (ch is not '?')
+                            throw new ParseException("Invalid character after ')'", c);
 
-                    current.Value += '?';
-                }
-                else if (ch == '(')
-                {
-                    stack.Push(current);
-                    stack.Peek().Children.Add(current = new Node());
-                }
-                else
-                {
-                    current.Value += ch;
+                        current.Value += '?';
+                        break;
+                    }
+                    case '(':
+                        stack.Push(current);
+                        stack.Peek().Children.Add(current = new Node());
+                        break;
+                    default:
+                        current.Value += ch;
+                        break;
                 }
 
                 afterClosing = ch == ')' || (afterClosing && ch == '?');

--- a/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
+++ b/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
@@ -26,7 +26,7 @@ namespace XamlX.Parsers
         {
             var stack = new Stack<Node>();
             var current = new Node();
-            //Initial parser state with initial node added to the root parent
+            // Initial parser state with initial node added to the root parent
             stack.Push(current);
             current = new Node();
             stack.Peek().Children.Add(current);
@@ -39,8 +39,6 @@ namespace XamlX.Parsers
                 {
                     stack.Peek().Children.Add(current = new Node());
                 }
-                else if(afterClosing && char.IsWhiteSpace(ch))
-                    continue;
                 else if (ch == ')')
                 {
                     current = stack.Pop();
@@ -48,8 +46,16 @@ namespace XamlX.Parsers
                         throw new ParseException("Unmatched ')'", c);
                 }
                 else if (afterClosing)
-                    throw new ParseException("Invalid character after ')'", c);
-                else if(ch=='(')
+                {
+                    if (char.IsWhiteSpace(ch))
+                        continue;
+
+                    if (ch is not '?')
+                        throw new ParseException("Invalid character after ')'", c);
+
+                    current.Value += '?';
+                }
+                else if (ch == '(')
                 {
                     stack.Push(current);
                     stack.Peek().Children.Add(current = new Node());
@@ -59,7 +65,7 @@ namespace XamlX.Parsers
                     current.Value += ch;
                 }
 
-                afterClosing = ch == ')';
+                afterClosing = ch == ')' || (afterClosing && ch == '?');
             }
 
             // Final state: initial node at the top of the stack
@@ -69,5 +75,4 @@ namespace XamlX.Parsers
             return stack.Pop().Children;
         }
     }
-    
 }

--- a/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
+++ b/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
@@ -63,6 +63,9 @@ namespace XamlX.Parsers
             }
 
             // Final state: initial node at the top of the stack
+            if (stack.Count != 1)
+                throw new ParseException("Unmatched '('", s.Length);
+
             return stack.Pop().Children;
         }
     }

--- a/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
+++ b/src/XamlX/Parsers/CommaSeparatedParenthesesTreeParser.cs
@@ -45,7 +45,6 @@ namespace XamlX.Parsers
                         current = stack.Pop();
                         if (stack.Count == 0)
                             throw new ParseException("Unmatched ')'", c);
-                        // current.Value += $"`{current.Children.Count}";
                         break;
                     }
                     case { } when afterClosing:

--- a/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
+++ b/src/XamlX/Transform/Transformers/TypeReferenceResolver.cs
@@ -98,11 +98,23 @@ namespace XamlX.Transform.Transformers
                     }, name);
             }
 
-            if (typeArguments.Count != 0)
-                found = found?.MakeGenericType(targs);
             if (found != null)
+            {
+                if (targs.Count != 0)
+                {
+                    // Nullable<T> only accepts non-nullable value types.
+                    if (found.Equals(context.Configuration.WellKnownTypes.NullableT) && 
+                            targs[0] is {} targ && (!targ.IsValueType || targ.IsNullable()))
+                        throw new XamlTransformException(
+                            $"Unable to construct generic type {found.GetFullName()} with arguments {string.Join(", ", targs.Select(a => a.GetFullName()))}: type argument {targs[0].GetFullName()} must be a non-nullable value type",
+                            lineInfo);
+
+                    found = found.MakeGenericType(targs);
+                }
+
                 return new XamlAstClrTypeReference(lineInfo, found,
                     isMarkupExtension || found.Name.EndsWith("Extension"));
+            }
 
             throw new XamlTransformException($"Unable to resolve type {name} from namespace {xmlns}", lineInfo);
         }

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -60,6 +60,10 @@ namespace XamlX.Transform.Transformers
 
                     XamlAstXmlTypeReference ResolveSimpleTypeName(string typeName)
                     {
+                        bool isNullable = typeName.EndsWith("?");
+                        if (isNullable)
+                            typeName = typeName.TrimEnd('?');
+
                         var pair = typeName.Split(new[] { ':' }, 2);
                         if (pair.Length == 1)
                             pair = new[] { "", pair[0] };
@@ -67,7 +71,12 @@ namespace XamlX.Transform.Transformers
                         if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
                             throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNode);
 
-                        return new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
+                        var typeRef = new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
+
+                        if (isNullable)
+                            return MakeNullableTypeReference(typeRef);
+
+                        return typeRef;
                     }
 
                     XamlAstXmlTypeReference ResolveTypeExpression(string typeExpression)
@@ -86,9 +95,17 @@ namespace XamlX.Transform.Transformers
                                 if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
                                     throw new XamlTransformException("x:Type TypeName contains an empty type name", textNode);
 
-                                var typeReference = ResolveSimpleTypeName(parsedValue.Trim());
+                                var trimmed = parsedValue.Trim();
+                                bool isNullable = trimmed.EndsWith("?");
+                                if (isNullable)
+                                    trimmed = trimmed.Substring(0, trimmed.Length - 1);
+
+                                var typeReference = ResolveSimpleTypeName(trimmed);
                                 if (parsedNode.Children.Count != 0)
                                     typeReference.GenericArguments = parsedNode.Children.Select(ConvertNode).ToList();
+
+                                if (isNullable)
+                                    return MakeNullableTypeReference(typeReference);
 
                                 return typeReference;
                             }
@@ -105,12 +122,24 @@ namespace XamlX.Transform.Transformers
                         ? ResolveTypeExpression(typeRefText)
                         : ResolveSimpleTypeName(typeRefText);
 
-                    if (!hasInlineGenericSyntax)
+                    if (!hasInlineGenericSyntax && xml.GenericArguments.Count > 0)
                         typeReference.GenericArguments = xml.GenericArguments;
 
                     return new XamlTypeExtensionNode(node,
                         typeReference,
                         context.Configuration.WellKnownTypes.Type);
+
+                    XamlAstXmlTypeReference MakeNullableTypeReference(XamlAstXmlTypeReference typeRef)
+                    {
+                        var resolved = TypeReferenceResolver.ResolveType(context, typeRef);
+                        if (resolved.Type.IsNullable())
+                            throw new XamlTransformException(
+                                $"Type {resolved.Type.GetFqn()} is already nullable and cannot be made nullable again",
+                                textNode);
+                        if (resolved.Type.IsValueType)
+                            return new XamlAstXmlTypeReference(textNode, XamlNamespaces.Xaml2006, "Nullable`1", [typeRef]);
+                        return typeRef;
+                    }
                 }
 
                 if (xml.Name == "Static")
@@ -130,6 +159,9 @@ namespace XamlX.Transform.Transformers
 
                     XamlAstXmlTypeReference ResolveSimpleTypeName(string typeName)
                     {
+                        bool isNullable = typeName.EndsWith("?");
+                        if (isNullable) typeName = typeName.Substring(0, typeName.Length - 1);
+
                         var pair = typeName.Split(new[] { ':' }, 2);
                         if (pair.Length == 1)
                             pair = new[] { "", pair[0] };
@@ -137,7 +169,21 @@ namespace XamlX.Transform.Transformers
                         if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
                             throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNode);
 
-                        return new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
+                        var typeRef = new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
+
+                        if (isNullable)
+                        {
+                            var resolved = TypeReferenceResolver.ResolveType(context, typeRef);
+                            if (resolved.Type.IsNullable())
+                                throw new XamlTransformException(
+                                    $"Type {resolved.Type.GetFqn()} is already nullable and cannot be made nullable again",
+                                    textNode);
+                            if (resolved.Type.IsValueType)
+                                return new XamlAstXmlTypeReference(textNode, XamlNamespaces.Xaml2006, "Nullable`1",
+                                    new[] { typeRef });
+                        }
+
+                        return typeRef;
                     }
 
                     XamlAstXmlTypeReference ResolveTypeExpression(string typeExpression)
@@ -156,9 +202,25 @@ namespace XamlX.Transform.Transformers
                                 if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
                                     throw new XamlTransformException("x:Static Member contains an empty type name", textNode);
 
-                                var typeReference = ResolveSimpleTypeName(parsedValue.Trim());
+                                var trimmed = parsedValue.Trim();
+                                bool isNullable = trimmed.EndsWith("?");
+                                if (isNullable) trimmed = trimmed.Substring(0, trimmed.Length - 1);
+
+                                var typeReference = ResolveSimpleTypeName(trimmed);
                                 if (parsedNode.Children.Count != 0)
                                     typeReference.GenericArguments = parsedNode.Children.Select(ConvertNode).ToList();
+
+                                if (isNullable)
+                                {
+                                    var resolved = TypeReferenceResolver.ResolveType(context, typeReference);
+                                    if (resolved.Type.IsNullable())
+                                        throw new XamlTransformException(
+                                            $"Type {resolved.Type.GetFqn()} is already nullable and cannot be made nullable again",
+                                            textNode);
+                                    if (resolved.Type.IsValueType)
+                                        return new XamlAstXmlTypeReference(textNode, XamlNamespaces.Xaml2006, "Nullable`1",
+                                            new[] { typeReference });
+                                }
 
                                 return typeReference;
                             }
@@ -175,7 +237,7 @@ namespace XamlX.Transform.Transformers
                         ? ResolveTypeExpression(tmpair[0])
                         : ResolveSimpleTypeName(tmpair[0]);
 
-                    if (!hasInlineGenericSyntax)
+                    if (!hasInlineGenericSyntax && xml.GenericArguments.Count > 0)
                         typeReference.GenericArguments = xml.GenericArguments;
 
                     return new XamlStaticExtensionNode(ni,

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using XamlX.Ast;
+using XamlX.Parsers;
 using XamlX.TypeSystem;
 
 namespace XamlX.Transform.Transformers
@@ -49,43 +51,135 @@ namespace XamlX.Transform.Transformers
                 {
                     var textNode = ResolveArgumentOrValue("x:Type", "TypeName");
                     var typeRefText = textNode.Text.Trim();
-                    var pair = typeRefText.Split(new[] {':'}, 2);
-                    if (pair.Length == 1)
-                        pair = new[] {"", pair[0]};
+                    var hasInlineGenericSyntax = typeRefText.IndexOfAny(new[] { '(', ')' }) != -1;
 
-                    if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
-                        return context.ReportTransformError($"Unable to resolve namespace {pair[0]}", textNode, node);
+                    if (xml.GenericArguments.Count > 0 && hasInlineGenericSyntax)
+                        throw new XamlTransformException(
+                            "x:Type generic arguments cannot be specified in both TypeName and x:TypeArguments",
+                            textNode);
+
+                    XamlAstXmlTypeReference ResolveSimpleTypeName(string typeName)
+                    {
+                        var pair = typeName.Split(new[] { ':' }, 2);
+                        if (pair.Length == 1)
+                            pair = new[] { "", pair[0] };
+
+                        if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
+                            throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNode);
+
+                        return new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
+                    }
+
+                    XamlAstXmlTypeReference ResolveTypeExpression(string typeExpression)
+                    {
+                        try
+                        {
+                            var parsed = CommaSeparatedParenthesesTreeParser.Parse(typeExpression);
+                            if (parsed.Count != 1)
+                                throw new XamlTransformException(
+                                    "x:Type TypeName should contain exactly one type expression",
+                                    textNode);
+
+                            XamlAstXmlTypeReference ConvertNode(CommaSeparatedParenthesesTreeParser.Node parsedNode)
+                            {
+                                var parsedValue = parsedNode.Value;
+                                if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
+                                    throw new XamlTransformException("x:Type TypeName contains an empty type name", textNode);
+
+                                var typeReference = ResolveSimpleTypeName(parsedValue.Trim());
+                                if (parsedNode.Children.Count != 0)
+                                    typeReference.GenericArguments = parsedNode.Children.Select(ConvertNode).ToList();
+
+                                return typeReference;
+                            }
+
+                            return ConvertNode(parsed[0]);
+                        }
+                        catch (CommaSeparatedParenthesesTreeParser.ParseException e)
+                        {
+                            throw new XamlTransformException($"Unable to parse x:Type TypeName: {e.Message}", textNode, e);
+                        }
+                    }
+
+                    var typeReference = hasInlineGenericSyntax
+                        ? ResolveTypeExpression(typeRefText)
+                        : ResolveSimpleTypeName(typeRefText);
+
+                    if (!hasInlineGenericSyntax)
+                        typeReference.GenericArguments = xml.GenericArguments;
 
                     return new XamlTypeExtensionNode(node,
-                        new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1], xml.GenericArguments),
+                        typeReference,
                         context.Configuration.WellKnownTypes.Type);
                 }
 
                 if (xml.Name == "Static")
                 {
                     var textNode = ResolveArgumentOrValue("x:Static", "Member");
-                    var nsp = textNode.Text.Trim().Split(new[] {':'}, 2);
-                    string ns, typeAndMember;
-                    if (nsp.Length == 1)
+                    var typeRefText = textNode.Text.Trim();
+                    var hasInlineGenericSyntax = typeRefText.IndexOfAny(new[] { '(', ')' }) != -1;
+
+                    if (xml.GenericArguments.Count > 0 && hasInlineGenericSyntax)
+                        throw new XamlTransformException(
+                            "x:Static generic arguments cannot be specified in both Member and x:TypeArguments",
+                            textNode);
+
+                    var tmpair = typeRefText.Split(new[] { '.' }, 2);
+                    if (tmpair.Length != 2)
+                        throw new XamlTransformException($"Unable to parse {typeRefText} as 'type.member'", textNode);
+
+                    XamlAstXmlTypeReference ResolveSimpleTypeName(string typeName)
                     {
-                        ns = "";
-                        typeAndMember = nsp[0];
-                    }
-                    else
-                    {
-                        ns = nsp[0];
-                        typeAndMember = nsp[1];
+                        var pair = typeName.Split(new[] { ':' }, 2);
+                        if (pair.Length == 1)
+                            pair = new[] { "", pair[0] };
+
+                        if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
+                            throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNode);
+
+                        return new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
                     }
 
-                    var tmpair = typeAndMember.Split(new[] {'.'}, 2);
-                    if (tmpair.Length != 2)
-                        throw new XamlTransformException($"Unable to parse {typeAndMember} as 'type.member'", textNode);
-                    
-                    if (!context.NamespaceAliases.TryGetValue(ns, out var resolvedNs))
-                        throw new XamlTransformException($"Unable to resolve namespace {ns}", textNode);
-                    
+                    XamlAstXmlTypeReference ResolveTypeExpression(string typeExpression)
+                    {
+                        try
+                        {
+                            var tree = CommaSeparatedParenthesesTreeParser.Parse(typeExpression);
+                            if (tree.Count != 1)
+                                throw new XamlTransformException(
+                                    "x:Static Member should contain exactly one type expression",
+                                    textNode);
+
+                            XamlAstXmlTypeReference ConvertNode(CommaSeparatedParenthesesTreeParser.Node parsedNode)
+                            {
+                                var parsedValue = parsedNode.Value;
+                                if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
+                                    throw new XamlTransformException("x:Static Member contains an empty type name", textNode);
+
+                                var typeReference = ResolveSimpleTypeName(parsedValue.Trim());
+                                if (parsedNode.Children.Count != 0)
+                                    typeReference.GenericArguments = parsedNode.Children.Select(ConvertNode).ToList();
+
+                                return typeReference;
+                            }
+
+                            return ConvertNode(tree[0]);
+                        }
+                        catch (CommaSeparatedParenthesesTreeParser.ParseException e)
+                        {
+                            throw new XamlTransformException($"Unable to parse x:Static Member: {e.Message}", textNode, e);
+                        }
+                    }
+
+                    var typeReference = hasInlineGenericSyntax
+                        ? ResolveTypeExpression(tmpair[0])
+                        : ResolveSimpleTypeName(tmpair[0]);
+
+                    if (!hasInlineGenericSyntax)
+                        typeReference.GenericArguments = xml.GenericArguments;
+
                     return new XamlStaticExtensionNode(ni,
-                        new XamlAstXmlTypeReference(ni, resolvedNs, tmpair[0], xml.GenericArguments),
+                        typeReference,
                         tmpair[1]);
                 }
             }

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using XamlX.Ast;
@@ -18,235 +19,155 @@ namespace XamlX.Transform.Transformers
                 && ni.Type is XamlAstXmlTypeReference xml
                 && xml.XmlNamespace == XamlNamespaces.Xaml2006)
             {
-                XamlAstTextNode ResolveArgumentOrValue(string extension, string name)
+                switch (xml.Name)
                 {
-                    IXamlAstNode? value = null;
-                    
-                    if (ni.Arguments.Count == 1 && ni.Children.Count == 0)
-                        value = ni.Arguments[0];
-                    else if (ni.Arguments.Count == 0 && ni.Children.Count == 1
-                                                     && ni.Children[0] is XamlAstXamlPropertyValueNode pnode
-                                                     && pnode.Property is XamlAstNamePropertyReference pref
-                                                     && pref.Name == name
-                                                     && pnode.Values.Count == 1) 
-                        value = pnode.Values[0];
-
-                    if(value == null)
-                        throw new XamlTransformException(
-                            $"{extension} extension should take exactly one constructor parameter without any content OR {name} property",
-                            node);
-
-                    if (!(value is XamlAstTextNode textNode))
-                        throw new XamlTransformException("x:Type parameter should be a text node", node);
-                    return textNode;
-                }
-
-                if (xml.Name == "Null")
-                    return new XamlNullExtensionNode(node);
-                if (xml.Name == "True")
-                    return new XamlConstantNode(node, context.Configuration.WellKnownTypes.Boolean, true);
-                if (xml.Name == "False")
-                    return new XamlConstantNode(node, context.Configuration.WellKnownTypes.Boolean, false);
-                if (xml.Name == "Type")
-                {
-                    var textNode = ResolveArgumentOrValue("x:Type", "TypeName");
-                    var typeRefText = textNode.Text.Trim();
-                    var hasInlineGenericSyntax = typeRefText.IndexOfAny(new[] { '(', ')' }) != -1;
-
-                    if (xml.GenericArguments.Count > 0 && hasInlineGenericSyntax)
-                        throw new XamlTransformException(
-                            "x:Type generic arguments cannot be specified in both TypeName and x:TypeArguments",
-                            textNode);
-
-                    XamlAstXmlTypeReference ResolveSimpleTypeName(string typeName)
+                    case "Null":
+                        return new XamlNullExtensionNode(node);
+                    case "True":
+                        return new XamlConstantNode(node, context.Configuration.WellKnownTypes.Boolean, true);
+                    case "False":
+                        return new XamlConstantNode(node, context.Configuration.WellKnownTypes.Boolean, false);
+                    case "Type":
                     {
-                        bool isNullable = typeName.EndsWith("?");
-                        if (isNullable)
-                            typeName = typeName.TrimEnd('?');
+                        var textNode = ResolveArgumentOrValue("x:Type", "TypeName");
+                        var typeRefText = textNode.Text.Trim();
 
-                        var pair = typeName.Split(new[] { ':' }, 2);
-                        if (pair.Length == 1)
-                            pair = new[] { "", pair[0] };
+                        var typeReference = ResolveTypeExpression("x:Type", typeRefText, textNode);
 
-                        if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
-                            throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNode);
-
-                        var typeRef = new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
-
-                        if (isNullable)
-                            return MakeNullableTypeReference(typeRef);
-
-                        return typeRef;
+                        return new XamlTypeExtensionNode(node,
+                            typeReference,
+                            context.Configuration.TypeSystem.GetType("System.Type"));
                     }
-
-                    XamlAstXmlTypeReference ResolveTypeExpression(string typeExpression)
+                    case "Static":
                     {
-                        try
-                        {
-                            var parsed = CommaSeparatedParenthesesTreeParser.Parse(typeExpression);
-                            if (parsed.Count != 1)
-                                throw new XamlTransformException(
-                                    "x:Type TypeName should contain exactly one type expression",
-                                    textNode);
+                        var textNode = ResolveArgumentOrValue("x:Static", "Member");
+                        var typeRefText = textNode.Text.Trim();
 
-                            XamlAstXmlTypeReference ConvertNode(CommaSeparatedParenthesesTreeParser.Node parsedNode)
-                            {
-                                var parsedValue = parsedNode.Value;
-                                if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
-                                    throw new XamlTransformException("x:Type TypeName contains an empty type name", textNode);
+                        var tmpair = typeRefText.Split(['.'], 2);
 
-                                var trimmed = parsedValue.Trim();
-                                bool isNullable = trimmed.EndsWith("?");
-                                if (isNullable)
-                                    trimmed = trimmed.Substring(0, trimmed.Length - 1);
+                        if (tmpair.Length != 2)
+                            throw new XamlTransformException($"Unable to parse {typeRefText} as 'type.member'", textNode);
 
-                                var typeReference = ResolveSimpleTypeName(trimmed);
-                                if (parsedNode.Children.Count != 0)
-                                    typeReference.GenericArguments = parsedNode.Children.Select(ConvertNode).ToList();
+                        var typeReference = ResolveTypeExpression("x:Static", tmpair[0], textNode);
 
-                                if (isNullable)
-                                    return MakeNullableTypeReference(typeReference);
-
-                                return typeReference;
-                            }
-
-                            return ConvertNode(parsed[0]);
-                        }
-                        catch (CommaSeparatedParenthesesTreeParser.ParseException e)
-                        {
-                            throw new XamlTransformException($"Unable to parse x:Type TypeName: {e.Message}", textNode, e);
-                        }
+                        return new XamlStaticExtensionNode(ni,
+                            typeReference,
+                            tmpair[1]);
                     }
-
-                    var typeReference = hasInlineGenericSyntax
-                        ? ResolveTypeExpression(typeRefText)
-                        : ResolveSimpleTypeName(typeRefText);
-
-                    if (!hasInlineGenericSyntax && xml.GenericArguments.Count > 0)
-                        typeReference.GenericArguments = xml.GenericArguments;
-
-                    return new XamlTypeExtensionNode(node,
-                        typeReference,
-                        context.Configuration.WellKnownTypes.Type);
-
-                    XamlAstXmlTypeReference MakeNullableTypeReference(XamlAstXmlTypeReference typeRef)
-                    {
-                        var resolved = TypeReferenceResolver.ResolveType(context, typeRef);
-                        if (resolved.Type.IsNullable())
-                            throw new XamlTransformException(
-                                $"Type {resolved.Type.GetFqn()} is already nullable and cannot be made nullable again",
-                                textNode);
-                        if (resolved.Type.IsValueType)
-                            return new XamlAstXmlTypeReference(textNode, XamlNamespaces.Xaml2006, "Nullable`1", [typeRef]);
-                        return typeRef;
-                    }
-                }
-
-                if (xml.Name == "Static")
-                {
-                    var textNode = ResolveArgumentOrValue("x:Static", "Member");
-                    var typeRefText = textNode.Text.Trim();
-                    var hasInlineGenericSyntax = typeRefText.IndexOfAny(new[] { '(', ')' }) != -1;
-
-                    if (xml.GenericArguments.Count > 0 && hasInlineGenericSyntax)
-                        throw new XamlTransformException(
-                            "x:Static generic arguments cannot be specified in both Member and x:TypeArguments",
-                            textNode);
-
-                    var tmpair = typeRefText.Split(new[] { '.' }, 2);
-                    if (tmpair.Length != 2)
-                        throw new XamlTransformException($"Unable to parse {typeRefText} as 'type.member'", textNode);
-
-                    XamlAstXmlTypeReference ResolveSimpleTypeName(string typeName)
-                    {
-                        bool isNullable = typeName.EndsWith("?");
-                        if (isNullable) typeName = typeName.Substring(0, typeName.Length - 1);
-
-                        var pair = typeName.Split(new[] { ':' }, 2);
-                        if (pair.Length == 1)
-                            pair = new[] { "", pair[0] };
-
-                        if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
-                            throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNode);
-
-                        var typeRef = new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1].Trim());
-
-                        if (isNullable)
-                        {
-                            var resolved = TypeReferenceResolver.ResolveType(context, typeRef);
-                            if (resolved.Type.IsNullable())
-                                throw new XamlTransformException(
-                                    $"Type {resolved.Type.GetFqn()} is already nullable and cannot be made nullable again",
-                                    textNode);
-                            if (resolved.Type.IsValueType)
-                                return new XamlAstXmlTypeReference(textNode, XamlNamespaces.Xaml2006, "Nullable`1",
-                                    new[] { typeRef });
-                        }
-
-                        return typeRef;
-                    }
-
-                    XamlAstXmlTypeReference ResolveTypeExpression(string typeExpression)
-                    {
-                        try
-                        {
-                            var tree = CommaSeparatedParenthesesTreeParser.Parse(typeExpression);
-                            if (tree.Count != 1)
-                                throw new XamlTransformException(
-                                    "x:Static Member should contain exactly one type expression",
-                                    textNode);
-
-                            XamlAstXmlTypeReference ConvertNode(CommaSeparatedParenthesesTreeParser.Node parsedNode)
-                            {
-                                var parsedValue = parsedNode.Value;
-                                if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
-                                    throw new XamlTransformException("x:Static Member contains an empty type name", textNode);
-
-                                var trimmed = parsedValue.Trim();
-                                bool isNullable = trimmed.EndsWith("?");
-                                if (isNullable) trimmed = trimmed.Substring(0, trimmed.Length - 1);
-
-                                var typeReference = ResolveSimpleTypeName(trimmed);
-                                if (parsedNode.Children.Count != 0)
-                                    typeReference.GenericArguments = parsedNode.Children.Select(ConvertNode).ToList();
-
-                                if (isNullable)
-                                {
-                                    var resolved = TypeReferenceResolver.ResolveType(context, typeReference);
-                                    if (resolved.Type.IsNullable())
-                                        throw new XamlTransformException(
-                                            $"Type {resolved.Type.GetFqn()} is already nullable and cannot be made nullable again",
-                                            textNode);
-                                    if (resolved.Type.IsValueType)
-                                        return new XamlAstXmlTypeReference(textNode, XamlNamespaces.Xaml2006, "Nullable`1",
-                                            new[] { typeReference });
-                                }
-
-                                return typeReference;
-                            }
-
-                            return ConvertNode(tree[0]);
-                        }
-                        catch (CommaSeparatedParenthesesTreeParser.ParseException e)
-                        {
-                            throw new XamlTransformException($"Unable to parse x:Static Member: {e.Message}", textNode, e);
-                        }
-                    }
-
-                    var typeReference = hasInlineGenericSyntax
-                        ? ResolveTypeExpression(tmpair[0])
-                        : ResolveSimpleTypeName(tmpair[0]);
-
-                    if (!hasInlineGenericSyntax && xml.GenericArguments.Count > 0)
-                        typeReference.GenericArguments = xml.GenericArguments;
-
-                    return new XamlStaticExtensionNode(ni,
-                        typeReference,
-                        tmpair[1]);
                 }
             }
 
             return node;
+
+
+            XamlAstTextNode ResolveArgumentOrValue(string extension, string name)
+            {
+                IXamlAstNode? value = null;
+
+                if (ni.Arguments.Count == 1 && ni.Children.Count == 0)
+                    value = ni.Arguments[0];
+                else if (ni.Arguments.Count == 0
+                         && ni.Children.Count == 1
+                         && ni.Children[0] is XamlAstXamlPropertyValueNode pNode
+                         && pNode.Property is XamlAstNamePropertyReference pRef
+                         && pRef.Name == name
+                         && pNode.Values.Count == 1)
+                    value = pNode.Values[0];
+
+                if (value == null)
+                    throw new XamlTransformException(
+                        $"{extension} extension should take exactly one constructor parameter without any content OR {name} property",
+                        node);
+
+                if (!(value is XamlAstTextNode textNode))
+                    throw new XamlTransformException("x:Type parameter should be a text node", node);
+                return textNode;
+            }
+
+            XamlAstXmlTypeReference ResolveTypeExpression(string extensionName, string typeExpression,
+                XamlAstTextNode textNode)
+            {
+                var hasInlineGenericSyntax = typeExpression.IndexOfAny(['(', ')']) != -1;
+
+                if (xml.GenericArguments.Count > 0 && hasInlineGenericSyntax)
+                    throw new XamlTransformException(
+                        $"{extensionName} generic arguments cannot be specified both inline and in x:TypeArguments",
+                        textNode);
+
+                if (hasInlineGenericSyntax)
+                {
+                    try
+                    {
+                        var tree = CommaSeparatedParenthesesTreeParser.Parse(typeExpression);
+                        if (tree.Count != 1)
+                            throw new XamlTransformException(
+                                $"{extensionName} should contain exactly one type expression",
+                                textNode);
+
+                        return ConvertNode(tree[0]);
+                    }
+                    catch (CommaSeparatedParenthesesTreeParser.ParseException e)
+                    {
+                        throw new XamlTransformException($"Unable to parse {extensionName}: {e.Message}", textNode, e);
+                    }
+                }
+
+                var typeRef = ResolveTypeName(typeExpression, textNode, null);
+
+                if (xml.GenericArguments.Count > 0)
+                    typeRef.GenericArguments = xml.GenericArguments;
+
+                return typeRef;
+
+                XamlAstXmlTypeReference ConvertNode(CommaSeparatedParenthesesTreeParser.Node parsedNode)
+                {
+                    var parsedValue = parsedNode.Value;
+                    if (parsedValue == null || string.IsNullOrWhiteSpace(parsedValue))
+                        throw new XamlTransformException($"{extensionName} contains an empty type name", textNode);
+
+                    var trimmed = parsedValue.Trim();
+
+                    var genericArguments = parsedNode.Children.Select(ConvertNode).ToList();
+                    var typeReference = ResolveTypeName(trimmed, textNode, genericArguments);
+
+                    return typeReference;
+                }
+
+
+                XamlAstXmlTypeReference ResolveTypeName(string typeName, XamlAstTextNode textNodeInner, List<XamlAstXmlTypeReference>? genericArguments)
+                {
+                    var isNullable = typeName.EndsWith("?");
+                    if (isNullable)
+                        typeName = typeName.Substring(0, typeName.Length - 1);
+
+                    if (typeName.Contains("?"))
+                        throw new XamlTransformException(
+                            $"Type {typeName}? is cannot contain multiple nullable indicators ('?')",
+                            textNodeInner);
+
+                    var pair = typeName.Split([':'], 2);
+                    if (pair.Length == 1)
+                        pair = ["", pair[0]];
+
+                    if (!context.NamespaceAliases.TryGetValue(pair[0].Trim(), out var resolvedNs))
+                        throw new XamlTransformException($"Unable to resolve namespace {pair[0]}", textNodeInner);
+
+                    var typeReference = new XamlAstXmlTypeReference(textNodeInner, resolvedNs, pair[1].Trim());
+
+                    if (genericArguments is not null)
+                        typeReference.GenericArguments = genericArguments;
+
+                    if (isNullable)
+                    {
+                        var resolved = TypeReferenceResolver.ResolveType(context, typeReference);
+                        if (resolved.Type.IsValueType)
+                            return new XamlAstXmlTypeReference(textNodeInner, XamlNamespaces.Xaml2006, "Nullable`1",
+                                [typeReference]);
+                    }
+
+                    return typeReference;
+                }
+            }
         }
     }
 }

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -140,7 +140,7 @@ namespace XamlX.Transform.Transformers
                     if (isNullable)
                         typeName = typeName.Substring(0, typeName.Length - 1);
 
-                    if (typeName.Contains("?"))
+                    if (typeName.Contains('?'))
                         throw new XamlTransformException(
                             $"Type {typeName}? is cannot contain multiple nullable indicators ('?')",
                             textNodeInner);

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -84,7 +84,11 @@ namespace XamlParserTests
          InlineData(typeof(Dictionary<string, List<int>>), "<x:Type TypeName='scg:Dictionary(x:String, scg:List(x:Int32))' />"),
          InlineData(typeof(List<string>), "<x:Type x:TypeArguments='x:String' TypeName='scg:List' />"),
          InlineData(typeof(List<List<string>>), "<x:Type x:TypeArguments='scg:List(x:String)' TypeName='scg:List'/>"),
-         InlineData(typeof(Dictionary<string, List<int>>), "<x:Type x:TypeArguments='x:String, scg:List(x:Int32)' TypeName='scg:Dictionary' />")
+         InlineData(typeof(Dictionary<string, List<int>>), "<x:Type x:TypeArguments='x:String, scg:List(x:Int32)' TypeName='scg:Dictionary' />"),
+         InlineData(typeof(int?), "<x:Type TypeName='x:Int32?' />"),
+         InlineData(typeof(int?), "<x:Type TypeName='sys:Nullable(x:Int32)' />"),
+         InlineData(typeof(string), "<x:Type TypeName='x:String?' />"),
+         InlineData(typeof(List<int?>), "<x:Type TypeName='scg:List(x:Int32?)' />"),
         ]
         public void Type_Extension_Resolves_Types(Type expectedType, string typeExt)
         {
@@ -92,6 +96,7 @@ namespace XamlParserTests
 <IntrinsicsTestsClass 
     xmlns='test' 
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'
     xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
 >
     <IntrinsicsTestsClass.TypeProperty>{typeExt}</IntrinsicsTestsClass.TypeProperty>
@@ -106,7 +111,13 @@ namespace XamlParserTests
          InlineData(typeof(Dictionary<string, string>), "{x:Type 'scg:Dictionary(x:String, x:String)'}"),
          InlineData(typeof(Dictionary<string, List<int>>), "{x:Type TypeName='scg:Dictionary(x:String, scg:List(x:Int32))'}"),
          InlineData(typeof(Dictionary<string, List<int>>), "{x:Type 'scg:Dictionary(x:String, scg:List(x:Int32))'}"),
-         InlineData(typeof(Dictionary<string, List<int>>), "{x:Type x:TypeArguments='x:String, scg:List(x:Int32)' TypeName='scg:Dictionary' }")
+         InlineData(typeof(Dictionary<string, List<int>>), "{x:Type x:TypeArguments='x:String, scg:List(x:Int32)' TypeName='scg:Dictionary' }"),
+         InlineData(typeof(int?), "{x:Type x:Int32?}"),
+         InlineData(typeof(int?), "{x:Type sys:Nullable(x:Int32)}"),
+         InlineData(typeof(string), "{x:Type x:String?}"),
+         InlineData(typeof(int?), "{x:Type TypeName=x:Int32?}"),
+         InlineData(typeof(List<int?>), "{x:Type TypeName='scg:List(x:Int32?)'}"),
+         InlineData(typeof(List<int?>), "{x:Type 'scg:List(x:Int32?)'}"),
         ]
         public void Type_MarkupExtension_Resolves_Types(Type expectedType, string typeExt)
         {
@@ -114,6 +125,7 @@ namespace XamlParserTests
 <IntrinsicsTestsClass 
     xmlns='test' 
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'
     xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
     TypeProperty=""{typeExt}"" />");
             Assert.Equal(expectedType, res.TypeProperty);
@@ -181,6 +193,22 @@ namespace XamlParserTests
             Assert.Contains("Unmatched '('", ex.Message);
         }
         
+        [Theory,
+         InlineData("<x:Type TypeName='sys:Nullable(x:Int32)?' />")
+        ]
+        public void Type_Extension_Should_Report_Error_When_Nullable_Is_Applied_To_Nullable(string typeExt)
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+>
+    <IntrinsicsTestsClass.TypeProperty>{typeExt}</IntrinsicsTestsClass.TypeProperty>
+</IntrinsicsTestsClass>"));
+            Assert.Contains("already nullable", ex.Message);
+        }
         
 
         [Theory,
@@ -197,7 +225,9 @@ namespace XamlParserTests
          InlineData("GenericStaticFieldValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:String, scg:List(x:Int32)).StaticField'/>"),
          InlineData("GenericStaticFieldValue", "<x:Static Member='IntrinsicsTestsGenericClass.StaticField'  x:TypeArguments='x:String, scg:List(x:Int32)'/>"),
          InlineData("GenericConstantValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StringConstant'/>"),
-         InlineData("GenericConstantValue", "<x:Static Member='IntrinsicsTestsGenericClass.StringConstant' x:TypeArguments='x:String, x:String'/>")
+         InlineData("GenericConstantValue", "<x:Static Member='IntrinsicsTestsGenericClass.StringConstant' x:TypeArguments='x:String, x:String'/>"),
+         InlineData("GenericStaticPropValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:Int32?, x:String).StaticProp'/>"),
+         InlineData("GenericStaticFieldValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:Int32?, scg:List(x:Int32)).StaticField'/>")
         ]
         public void Static_Extension_Resolves_Values(object expected, string r)
         {
@@ -221,7 +251,8 @@ namespace XamlParserTests
          InlineData("GenericStaticFieldValue", "{x:Static Member='IntrinsicsTestsGenericClass(x:String, scg:List(x:Int32)).StaticField'}"),
          InlineData("GenericStaticFieldValue", "{x:Static x:TypeArguments='x:String, scg:List(x:Int32)', Member='IntrinsicsTestsGenericClass.StaticField'}"),
          InlineData("GenericConstantValue", "{x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StringConstant'}"),
-         InlineData("GenericConstantValue", "{x:Static x:TypeArguments='x:String, x:String', Member='IntrinsicsTestsGenericClass.StringConstant'}")]
+         InlineData("GenericConstantValue", "{x:Static x:TypeArguments='x:String, x:String', Member='IntrinsicsTestsGenericClass.StringConstant'}"),
+         InlineData("GenericStaticPropValue", "{x:Static Member='IntrinsicsTestsGenericClass(x:Int32?, x:String).StaticProp'}")]
         public void Static_MarkupExtension_Resolves_Values(object expected, string markup)
         {
             var res = (IntrinsicsTestsClass) CompileAndRun($@"

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -23,6 +23,13 @@ namespace XamlParserTests
 
     public class IntrinsicsTestsDerivedClass : IntrinsicsTestsClass;
 
+    public class IntrinsicsTestsGenericClass<T1, T2>
+    {
+        public static object StaticProp { get; } = "GenericStaticPropValue";
+        public static object StaticField = "GenericStaticFieldValue";
+        public const string StringConstant = "GenericConstantValue";
+    }
+
     public class IntrinsicsListTestsClass
     {
         internal int AddInt32CallCount;
@@ -73,7 +80,11 @@ namespace XamlParserTests
 
         [Theory,
          InlineData(typeof(IntrinsicsTestsClass), "<x:Type TypeName='IntrinsicsTestsClass' />"),
-         InlineData(typeof(List<string>), "<x:Type x:TypeArguments='x:String' TypeName='scg:List' />")
+         InlineData(typeof(Dictionary<string, string>), "<x:Type TypeName='scg:Dictionary(x:String, x:String)' />"),
+         InlineData(typeof(Dictionary<string, List<int>>), "<x:Type TypeName='scg:Dictionary(x:String, scg:List(x:Int32))' />"),
+         InlineData(typeof(List<string>), "<x:Type x:TypeArguments='x:String' TypeName='scg:List' />"),
+         InlineData(typeof(List<List<string>>), "<x:Type x:TypeArguments='scg:List(x:String)' TypeName='scg:List'/>"),
+         InlineData(typeof(Dictionary<string, List<int>>), "<x:Type x:TypeArguments='x:String, scg:List(x:Int32)' TypeName='scg:Dictionary' />")
         ]
         public void Type_Extension_Resolves_Types(Type expectedType, string typeExt)
         {
@@ -86,17 +97,107 @@ namespace XamlParserTests
     <IntrinsicsTestsClass.TypeProperty>{typeExt}</IntrinsicsTestsClass.TypeProperty>
 </IntrinsicsTestsClass>");
             Assert.Equal(expectedType, res.TypeProperty);
+        }       
+        
+        [Theory,
+         InlineData(typeof(string), "{x:Type x:String}"),
+         InlineData(typeof(string), "{x:Type TypeName=x:String}"),
+         InlineData(typeof(Dictionary<string, string>), "{x:Type TypeName='scg:Dictionary(x:String, x:String)'}"),
+         InlineData(typeof(Dictionary<string, string>), "{x:Type 'scg:Dictionary(x:String, x:String)'}"),
+         InlineData(typeof(Dictionary<string, List<int>>), "{x:Type TypeName='scg:Dictionary(x:String, scg:List(x:Int32))'}"),
+         InlineData(typeof(Dictionary<string, List<int>>), "{x:Type 'scg:Dictionary(x:String, scg:List(x:Int32))'}"),
+         InlineData(typeof(Dictionary<string, List<int>>), "{x:Type x:TypeArguments='x:String, scg:List(x:Int32)' TypeName='scg:Dictionary' }")
+        ]
+        public void Type_MarkupExtension_Resolves_Types(Type expectedType, string typeExt)
+        {
+            var res = (IntrinsicsTestsClass) CompileAndRun($@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+    TypeProperty=""{typeExt}"" />");
+            Assert.Equal(expectedType, res.TypeProperty);
         }
 
+        [Fact]
+        public void Type_Extension_Should_Report_Error_When_TypeName_Generics_Are_Mixed_With_XTypeArguments()
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass
+    xmlns='test'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+>
+    <IntrinsicsTestsClass.TypeProperty>
+        <x:Type TypeName='scg:Dictionary(x:String, x:String)' x:TypeArguments='x:String, x:String' />
+    </IntrinsicsTestsClass.TypeProperty>
+</IntrinsicsTestsClass>"));
+
+            Assert.Contains("both TypeName and x:TypeArguments", ex.Message);
+        }
+
+        [Fact]
+        public void Type_MarkupExtension_Should_Report_Error_When_TypeName_Generics_Are_Mixed_With_XTypeArguments()
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass
+    xmlns='test'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+    TypeProperty=""{{x:Type TypeName='scg:Dictionary(x:String, x:String)', x:TypeArguments='x:String, x:String' }}"" />"));
+
+            Assert.Contains("both TypeName and x:TypeArguments", ex.Message);
+        }
+
+        [Fact]
+        public void Type_Extension_Should_Report_Error_When_Inline_Generic_Syntax_Is_Unbalanced()
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass
+    xmlns='test'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+>
+    <IntrinsicsTestsClass.TypeProperty>
+        <x:Type TypeName='scg:List(x:String' />
+    </IntrinsicsTestsClass.TypeProperty>
+</IntrinsicsTestsClass>"));
+
+            Assert.Contains("Unable to parse x:Type TypeName", ex.Message);
+            Assert.Contains("Unmatched '('", ex.Message);
+        }
+
+        [Fact]
+        public void Type_MarkupExtension_Should_Report_Error_When_Inline_Generic_Syntax_Is_Unbalanced()
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass
+    xmlns='test'
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+    TypeProperty=""{{x:Type TypeName='scg:List(x:String'}}"" />"));
+
+            Assert.Contains("Unable to parse x:Type TypeName", ex.Message);
+            Assert.Contains("Unmatched '('", ex.Message);
+        }
+        
+        
+
         [Theory,
-         InlineData("StaticPropValue", "IntrinsicsTestsClass.StaticProp"),
-         InlineData("StaticFieldValue", "IntrinsicsTestsClass.StaticField"),
-         InlineData("ConstantValue", "IntrinsicsTestsClass.StringConstant"),
-         InlineData(100, "IntrinsicsTestsClass.IntConstant"),
-         InlineData(2f, "IntrinsicsTestsClass.FloatConstant"),
-         InlineData(3d, "IntrinsicsTestsClass.DoubleConstant"),
-         InlineData("StaticPropValue", "IntrinsicsTestsDerivedClass.StaticProp"),
-         InlineData("StaticFieldValue", "IntrinsicsTestsDerivedClass.StaticField"),
+         InlineData("StaticPropValue", "<x:Static Member='IntrinsicsTestsClass.StaticProp'/>"),
+         InlineData("StaticFieldValue", "<x:Static Member='IntrinsicsTestsClass.StaticField'/>"),
+         InlineData("ConstantValue", "<x:Static Member='IntrinsicsTestsClass.StringConstant'/>"),
+         InlineData(100, "<x:Static Member='IntrinsicsTestsClass.IntConstant'/>"),
+         InlineData(2f, "<x:Static Member='IntrinsicsTestsClass.FloatConstant'/>"),
+         InlineData(3d, "<x:Static Member='IntrinsicsTestsClass.DoubleConstant'/>"),
+         InlineData("StaticPropValue", "<x:Static Member='IntrinsicsTestsDerivedClass.StaticProp'/>"),
+         InlineData("StaticFieldValue", "<x:Static Member='IntrinsicsTestsDerivedClass.StaticField'/>"),
+         InlineData("GenericStaticPropValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StaticProp'/>"),
+         InlineData("GenericStaticPropValue", "<x:Static Member='IntrinsicsTestsGenericClass.StaticProp' x:TypeArguments='x:String, x:String'/>"),
+         InlineData("GenericStaticFieldValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:String, scg:List(x:Int32)).StaticField'/>"),
+         InlineData("GenericStaticFieldValue", "<x:Static Member='IntrinsicsTestsGenericClass.StaticField'  x:TypeArguments='x:String, scg:List(x:Int32)'/>"),
+         InlineData("GenericConstantValue", "<x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StringConstant'/>"),
+         InlineData("GenericConstantValue", "<x:Static Member='IntrinsicsTestsGenericClass.StringConstant' x:TypeArguments='x:String, x:String'/>")
         ]
         public void Static_Extension_Resolves_Values(object expected, string r)
         {
@@ -104,10 +205,31 @@ namespace XamlParserTests
 <IntrinsicsTestsClass 
     xmlns='test' 
     xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
-    xmlns:scg='clr-namespace:System.Collections.Generic'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
 >
-    <IntrinsicsTestsClass.ObjectProperty><x:Static Member='{r}'/></IntrinsicsTestsClass.ObjectProperty>
+    <IntrinsicsTestsClass.ObjectProperty>{r}</IntrinsicsTestsClass.ObjectProperty>
 </IntrinsicsTestsClass>");
+            Assert.Equal(expected, res.ObjectProperty);
+        }
+
+        [Theory,
+         InlineData("StaticPropValue", "{x:Static Member='IntrinsicsTestsClass.StaticProp'}"),
+         InlineData("StaticFieldValue", "{x:Static Member='IntrinsicsTestsClass.StaticField'}"),
+         InlineData("ConstantValue", "{x:Static Member='IntrinsicsTestsClass.StringConstant'}"),
+         InlineData("GenericStaticPropValue", "{x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StaticProp'}"),
+         InlineData("GenericStaticPropValue", "{x:Static x:TypeArguments='x:String, x:String', Member='IntrinsicsTestsGenericClass.StaticProp'}"),
+         InlineData("GenericStaticFieldValue", "{x:Static Member='IntrinsicsTestsGenericClass(x:String, scg:List(x:Int32)).StaticField'}"),
+         InlineData("GenericStaticFieldValue", "{x:Static x:TypeArguments='x:String, scg:List(x:Int32)', Member='IntrinsicsTestsGenericClass.StaticField'}"),
+         InlineData("GenericConstantValue", "{x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StringConstant'}"),
+         InlineData("GenericConstantValue", "{x:Static x:TypeArguments='x:String, x:String', Member='IntrinsicsTestsGenericClass.StringConstant'}")]
+        public void Static_MarkupExtension_Resolves_Values(object expected, string markup)
+        {
+            var res = (IntrinsicsTestsClass) CompileAndRun($@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+    ObjectProperty=""{markup}"" />");
             Assert.Equal(expected, res.ObjectProperty);
         }
 
@@ -129,11 +251,41 @@ namespace XamlParserTests
                 ex1 => Assert.Contains("StaticPropDoesntExist1", ex1.Message),
                 ex2 => Assert.Contains("StaticPropDoesntExist2", ex2.Message));
         }
+
+        [Fact]
+        public void Static_Extension_Should_Report_Error_When_Member_Generics_Are_Mixed_With_XTypeArguments()
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+>
+    <IntrinsicsTestsClass.ObjectProperty>
+        <x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StaticProp' x:TypeArguments='x:String, x:String' />
+    </IntrinsicsTestsClass.ObjectProperty>
+</IntrinsicsTestsClass>"));
+
+            Assert.Contains("both Member and x:TypeArguments", ex.Message);
+        }
+
+        [Fact]
+        public void Static_MarkupExtension_Should_Report_Error_When_Member_Generics_Are_Mixed_With_XTypeArguments()
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+    ObjectProperty=""{{x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StaticProp', x:TypeArguments='x:String, x:String' }}"" />"));
+
+            Assert.Contains("both Member and x:TypeArguments", ex.Message);
+        }
         
         [Fact]
         public void Static_Extension_Resolves_Enum_Values()
         {
-            Static_Extension_Resolves_Values(IntrinsicsTestsEnum.Foo, "IntrinsicsTestsEnum.Foo");
+            Static_Extension_Resolves_Values(IntrinsicsTestsEnum.Foo, "<x:Static Member='IntrinsicsTestsEnum.Foo'/>");
         }
 
         [Theory,

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -118,6 +118,7 @@ namespace XamlParserTests
          InlineData(typeof(int?), "{x:Type TypeName=x:Int32?}"),
          InlineData(typeof(List<int?>), "{x:Type TypeName='scg:List(x:Int32?)'}"),
          InlineData(typeof(List<int?>), "{x:Type 'scg:List(x:Int32?)'}"),
+         InlineData(typeof(KeyValuePair<int?, string>?), "{x:Type 'scg:KeyValuePair(x:Int32?, x:String?)?'}")
         ]
         public void Type_MarkupExtension_Resolves_Types(Type expectedType, string typeExt)
         {
@@ -145,7 +146,7 @@ namespace XamlParserTests
     </IntrinsicsTestsClass.TypeProperty>
 </IntrinsicsTestsClass>"));
 
-            Assert.Contains("both TypeName and x:TypeArguments", ex.Message);
+            Assert.Contains("both inline and in x:TypeArguments", ex.Message);
         }
 
         [Fact]
@@ -158,7 +159,7 @@ namespace XamlParserTests
     xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
     TypeProperty=""{{x:Type TypeName='scg:Dictionary(x:String, x:String)', x:TypeArguments='x:String, x:String' }}"" />"));
 
-            Assert.Contains("both TypeName and x:TypeArguments", ex.Message);
+            Assert.Contains("both inline and in x:TypeArguments", ex.Message);
         }
 
         [Fact]
@@ -175,7 +176,7 @@ namespace XamlParserTests
     </IntrinsicsTestsClass.TypeProperty>
 </IntrinsicsTestsClass>"));
 
-            Assert.Contains("Unable to parse x:Type TypeName", ex.Message);
+            Assert.Contains("Unable to parse x:Type", ex.Message);
             Assert.Contains("Unmatched '('", ex.Message);
         }
 
@@ -189,12 +190,16 @@ namespace XamlParserTests
     xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
     TypeProperty=""{{x:Type TypeName='scg:List(x:String'}}"" />"));
 
-            Assert.Contains("Unable to parse x:Type TypeName", ex.Message);
+            Assert.Contains("Unable to parse x:Type", ex.Message);
             Assert.Contains("Unmatched '('", ex.Message);
         }
         
         [Theory,
-         InlineData("<x:Type TypeName='sys:Nullable(x:Int32)?' />")
+         // InlineData("<x:Type TypeName='sys:Nullable(x:Int32)?' />"),
+         // InlineData("<x:Type TypeName='sys:Nullable(x:Int32?)' />"),
+         // InlineData("<x:Type TypeName='sys:Nullable(sys:Nullable(x:Int32))' />"),
+         InlineData("<x:Type TypeName='x:Int32??' />"),
+         InlineData("<x:Type TypeName='x:String??' />")
         ]
         public void Type_Extension_Should_Report_Error_When_Nullable_Is_Applied_To_Nullable(string typeExt)
         {
@@ -207,7 +212,7 @@ namespace XamlParserTests
 >
     <IntrinsicsTestsClass.TypeProperty>{typeExt}</IntrinsicsTestsClass.TypeProperty>
 </IntrinsicsTestsClass>"));
-            Assert.Contains("already nullable", ex.Message);
+            Assert.Contains("multiple nullable indicators", ex.Message);
         }
         
 
@@ -297,7 +302,7 @@ namespace XamlParserTests
     </IntrinsicsTestsClass.ObjectProperty>
 </IntrinsicsTestsClass>"));
 
-            Assert.Contains("both Member and x:TypeArguments", ex.Message);
+            Assert.Contains("both inline and in x:TypeArguments", ex.Message);
         }
 
         [Fact]
@@ -310,7 +315,7 @@ namespace XamlParserTests
     xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
     ObjectProperty=""{{x:Static Member='IntrinsicsTestsGenericClass(x:String, x:String).StaticProp', x:TypeArguments='x:String, x:String' }}"" />"));
 
-            Assert.Contains("both Member and x:TypeArguments", ex.Message);
+            Assert.Contains("both inline and in x:TypeArguments", ex.Message);
         }
         
         [Fact]

--- a/tests/XamlParserTests/IntrinsicsTests.cs
+++ b/tests/XamlParserTests/IntrinsicsTests.cs
@@ -195,13 +195,10 @@ namespace XamlParserTests
         }
         
         [Theory,
-         // InlineData("<x:Type TypeName='sys:Nullable(x:Int32)?' />"),
-         // InlineData("<x:Type TypeName='sys:Nullable(x:Int32?)' />"),
-         // InlineData("<x:Type TypeName='sys:Nullable(sys:Nullable(x:Int32))' />"),
          InlineData("<x:Type TypeName='x:Int32??' />"),
          InlineData("<x:Type TypeName='x:String??' />")
         ]
-        public void Type_Extension_Should_Report_Error_When_Nullable_Is_Applied_To_Nullable(string typeExt)
+        public void Type_Extension_Should_Report_Error_When_TypeName_Has_Multiple_Nullable_Indicators(string typeExt)
         {
             var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
 <IntrinsicsTestsClass 
@@ -214,8 +211,33 @@ namespace XamlParserTests
 </IntrinsicsTestsClass>"));
             Assert.Contains("multiple nullable indicators", ex.Message);
         }
-        
 
+        [Theory,
+         InlineData("<x:Type TypeName='sys:Nullable(x:Int32)?' />"),
+         InlineData("<x:Type TypeName='sys:Nullable(x:String)' />"),
+         InlineData("<x:Type TypeName='sys:Nullable(x:Object)' />"),
+         InlineData("<x:Type TypeName='sys:Nullable(x:Int32?)' />"),
+         InlineData("<x:Type TypeName='sys:Nullable(sys:Nullable(x:Int32))' />"),
+         InlineData("<x:Type TypeName='sys:Nullable' x:TypeArguments='x:String' />"),
+         InlineData("<x:Type TypeName='sys:Nullable' x:TypeArguments='x:Object' />"),
+         InlineData("<x:Type TypeName='sys:Nullable' x:TypeArguments='sys:Nullable(x:Int32)' />")
+        ]
+        public void Type_Extension_Should_Report_Error_When_Nullable_Type_Argument_Is_Not_NonNullable_Value_Type(string typeExt)
+        {
+            var ex = Assert.Throws<XamlTransformException>(() => Compile($@"
+<IntrinsicsTestsClass 
+    xmlns='test' 
+    xmlns:x='http://schemas.microsoft.com/winfx/2006/xaml'
+    xmlns:sys='clr-namespace:System;assembly=netstandard'
+    xmlns:scg='clr-namespace:System.Collections.Generic;assembly=netstandard'
+>
+    <IntrinsicsTestsClass.TypeProperty>{typeExt}</IntrinsicsTestsClass.TypeProperty>
+</IntrinsicsTestsClass>"));
+            Assert.Contains("Unable to construct generic type", ex.Message);
+            Assert.Contains("must be a non-nullable value type", ex.Message);
+            Assert.DoesNotContain("Internal compiler error", ex.Message);
+        }
+        
         [Theory,
          InlineData("StaticPropValue", "<x:Static Member='IntrinsicsTestsClass.StaticProp'/>"),
          InlineData("StaticFieldValue", "<x:Static Member='IntrinsicsTestsClass.StaticField'/>"),


### PR DESCRIPTION
Resolves #135 

This PR extends XamlX intrinsic handling so `x:Type` and `x:Static` can resolve generic type expressions written inline, including nested generics. Before this PR, all generic arguments had to be provided via `x:TypeArguments`. 

Also it adds nullable `?` notation as a shorthand, so you can write `x:Int32?`, instead of `sys:Nullable(x:Int32)`.

Examples now supported include:

```xaml
<x:Type TypeName='scg:List(x:String)' />
<IntrinsicsTestsClass TypeProperty="{x:Type scg:List(x:String)}" />

<x:Static Member='IntrinsicsTestsGenericClass(x:String, scg:List(x:Int32)).StaticField'/>
<IntrinsicsTestsClass ObjectProperty="{x:Static 'IntrinsicsTestsGenericClass(x:String, scg:List(x:Int32)).StaticField'}" />

<x:Type TypeName='x:Int32?' />
<IntrinsicsTestsClass TypeProperty="{x:Type scg:List(x:Int32?)}" />
``` 

## What Changed

- Added inline generic parsing for `x:Type TypeName=...`
- Added inline generic parsing for `x:Static Member=...`
- Added nullable shorthand support in inline type expressions, such as `x:Int32?`, which will transform nullable value types into `Nullable<int>`.
- Supports nested generic expressions and multiple generic parameters (e.g., `Dictionary<string, List<int>>`).
- Preserved existing `x:TypeArguments` behavior for non-inline cases.
- Added validation to reject ambiguous inputs where generics are specified both inline and via `x:TypeArguments`.
- Updated the comma/parentheses parser to report unmatched opening parentheses `(`. Previously, only unmatched closing parentheses `)` were reported, allowing malformed strings like `c:List(x:Int32` to pass and resolve to something wrong (`int` instead of `List<int>`).

## Added Tests

Expanded `IntrinsicsTests` coverage for:

- `x:Type` with inline generic arguments.
- `x:Type` with nested generic arguments.
- Nullable shorthand in x:Type
- Markup-extension forms of the above scenarios.
- `x:Static` on generic types.
- Generic static properties, fields, and constants.
- Existing syntax using `x:TypeArguments`.
- Invalid mixed syntax cases.
- Invalid unbalanced generic syntax cases.

All tests are passing locally.

## Behavior Changes / Compatibility

There are no intended breaking changes for valid, existing XAML.

There are checks to avoid inline syntax conflicts with existing syntax:

- `x:Type` now throws a `XamlTransformException` if generic arguments are specified both inline in `TypeName` and separately via `x:TypeArguments` (e.g., `{x:Type scg:List(x:String) x:TypeArguments=x:String}`).
- `x:Static` now throws a `XamlTransformException` if generic arguments are specified both inline in `Member` and separately via `x:TypeArguments` (e.g., `{x:Static TestClass(x:String).StaticField x:TypeArguments=x:String}`).
- Invalid nullable syntax such as repeated nullable markers