### PR TITLE
Improve type caching

### DIFF
--- a/src/XamlX.IL.Cecil/CecilAssembly.cs
+++ b/src/XamlX.IL.Cecil/CecilAssembly.cs
@@ -1,3 +1,4 @@
+using System;
 using Mono.Cecil;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +9,7 @@ namespace XamlX.TypeSystem
     {
         internal class CecilAssembly : IXamlAssembly
         {
-            private readonly Dictionary<string, IXamlType> _typeCache = new();
+            private readonly Dictionary<string, IXamlType?> _typeCache = new();
 
             public CecilTypeSystem TypeSystem { get; }
             public AssemblyDefinition Assembly { get; }
@@ -29,8 +30,17 @@ namespace XamlX.TypeSystem
 
             public IXamlType? FindType(string fullName)
             {
-                if (_typeCache.TryGetValue(fullName, out var rv))
-                    return rv;
+                if (!_typeCache.TryGetValue(fullName, out var type))
+                {
+                    type = ResolveType(fullName);
+                    _typeCache[fullName] = type;
+                }
+
+                return type;
+            }
+
+            private IXamlType? ResolveType(string fullName)
+            {
                 var asmRef = new AssemblyNameReference(Assembly.Name.Name, Assembly.Name.Version);
                 var lastDot = fullName.LastIndexOf('.');
                 var ns = string.Empty;
@@ -42,7 +52,7 @@ namespace XamlX.TypeSystem
                 }
 
                 TypeReference? tref = null;
-                TypeDefinition? tdef = null;
+                TypeDefinition? tdef;
                 var plus = fullName.IndexOf('+');
 
                 while (true)
@@ -64,7 +74,8 @@ namespace XamlX.TypeSystem
                     fullName = fullName.Substring(plus + 1);
                     plus = fullName.IndexOf('+');
                 }
-                return _typeCache[fullName] = TypeSystem.RootTypeResolveContext.Resolve(tdef);
+
+                return TypeSystem.RootTypeResolveContext.Resolve(tdef);
             }
         }
     }

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -35,7 +35,7 @@ namespace XamlX.TypeSystem
                 Reference = reference;
                 Definition = definition;
                 if (reference.IsArray)
-                    Definition = ((CecilType)TypeSystem.GetType("System.Array")).Definition;
+                    Definition = ((CecilType)TypeSystem.WellKnownTypes.Array).Definition;
 
                 TypeResolveContext = parentTypeResolveContext.Nested(reference);
             }

--- a/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeBuilder.cs
@@ -157,15 +157,15 @@ namespace XamlX.TypeSystem
                     _ => throw new ArgumentOutOfRangeException(nameof(visibility), visibility, null)
                 };
 
-                var builder = new TypeDefinition("", name, attrs, GetReference(TypeSystem.GetType("System.MulticastDelegate")));
+                var builder = new TypeDefinition("", name, attrs, GetReference(TypeSystem.WellKnownTypes.MulticastDelegate));
 
                 Definition.NestedTypes.Add(builder);
                 TypeSystem.AddCompilerGeneratedAttribute(builder);
 
                 var ctor = new MethodDefinition(".ctor", MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName | MethodAttributes.HideBySig, GetReference(returnType));
                 ctor.ImplAttributes = MethodImplAttributes.Managed | MethodImplAttributes.Runtime;
-                ctor.Parameters.Add(new ParameterDefinition(GetReference(TypeSystem.GetType("System.Object"))));
-                ctor.Parameters.Add(new ParameterDefinition(GetReference(TypeSystem.GetType("System.IntPtr"))));
+                ctor.Parameters.Add(new ParameterDefinition(GetReference(TypeSystem.WellKnownTypes.Object)));
+                ctor.Parameters.Add(new ParameterDefinition(GetReference(TypeSystem.WellKnownTypes.IntPtr)));
 
                 builder.Methods.Add(ctor);
 

--- a/src/XamlX.IL.Cecil/CecilTypeSystem.cs
+++ b/src/XamlX.IL.Cecil/CecilTypeSystem.cs
@@ -77,13 +77,27 @@ namespace XamlX.TypeSystem
 
             _compilerGeneratedAttribute = GetTypeReference(FindType("System.Runtime.CompilerServices.CompilerGeneratedAttribute")!).Resolve();
             _compilerGeneratedAttributeConstructor = _compilerGeneratedAttribute.GetConstructors().Single();
+
+            WellKnownTypes = new XamlTypeWellKnownTypes(this);
         }
 
         internal CecilTypeResolveContext RootTypeResolveContext { get; } 
         public IXamlAssembly? TargetAssembly { get; private set; }
         public AssemblyDefinition? TargetAssemblyDefinition { get; private set; }
-        public IEnumerable<IXamlAssembly> Assemblies => _asms.AsReadOnly();
-        public IXamlAssembly? FindAssembly(string name) => _asms.FirstOrDefault(a => a.Assembly.Name.Name == name);
+        public IEnumerable<IXamlAssembly> Assemblies => _asms;
+
+        public XamlTypeWellKnownTypes WellKnownTypes { get; }
+
+        public IXamlAssembly? FindAssembly(string name)
+        {
+            foreach (var assembly in _asms)
+            {
+                if (assembly.Assembly.Name.Name == name)
+                    return assembly;
+            }
+
+            return null;
+        }
 
         [UnconditionalSuppressMessage("Trimming", "IL2092", Justification = TrimmingMessages.Cecil)]
         public IXamlType? FindType(string name)

--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -704,8 +704,8 @@ namespace XamlX.Ast
             _deferredContentCustomizationTypeParameter = deferredContentCustomizationTypeParameter;
             Value = value;
 
-            _funcType = config.TypeSystem
-                .GetType("System.Func`2")
+            _funcType = config.WellKnownTypes
+                .GetFuncOfT(2)
                 .MakeGenericType(config.TypeMappings.ServiceProvider, config.WellKnownTypes.Object);
 
             var returnType = _deferredContentCustomization?.ReturnType ?? _funcType;

--- a/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
+++ b/src/XamlX/IL/Emitters/PropertyAssignmentEmitter.cs
@@ -248,7 +248,7 @@ namespace XamlX.IL.Emitters
                 else
                 {
                     codeGen
-                        .Newobj(context.Configuration.TypeSystem.GetType("System.NullReferenceException")
+                        .Newobj(context.Configuration.WellKnownTypes.NullReferenceException
                             .GetConstructor())
                         .Throw();
                 }
@@ -256,7 +256,7 @@ namespace XamlX.IL.Emitters
                 codeGen.MarkLabel(next);
 
                 codeGen
-                    .Newobj(context.Configuration.TypeSystem.GetType("System.InvalidCastException")
+                    .Newobj(context.Configuration.WellKnownTypes.InvalidCastException
                         .GetConstructor())
                     .Throw();
             }

--- a/src/XamlX/IL/NamespaceInfoProvider.cs
+++ b/src/XamlX/IL/NamespaceInfoProvider.cs
@@ -64,10 +64,10 @@ namespace XamlX.IL
                     "CreateNamespaces",
                     XamlVisibility.Private, true, false);
 
-                var roListType = configuration.TypeSystem.GetType("System.Collections.Generic.IReadOnlyList`1")
+                var roListType = configuration.WellKnownTypes.IReadOnlyListOfT
                     .MakeGenericType(nsInfoType);
 
-                var dictionaryType = configuration.TypeSystem.GetType("System.Collections.Generic.Dictionary`2")
+                var dictionaryType = configuration.WellKnownTypes.DictionaryOfT2
                     .MakeGenericType(configuration.WellKnownTypes.String, roListType);
 
                 var dictionaryCtor = dictionaryType.GetConstructor(new List<IXamlType> { configuration.WellKnownTypes.Int32 });

--- a/src/XamlX/IL/RuntimeContext.cs
+++ b/src/XamlX/IL/RuntimeContext.cs
@@ -24,7 +24,7 @@ namespace XamlX.IL
             {
                 if (staticProviders?.Count > 0)
                 {
-                    var so = codegen.TypeSystem.GetType("System.Object");
+                    var so = codegen.TypeSystem.WellKnownTypes.Object;
                     codegen.Ldc_I4(staticProviders.Count)
                         .Newarr(so);
                     for (var c = 0; c < staticProviders.Count; c++)
@@ -93,7 +93,7 @@ namespace XamlX.IL
             IXamlTypeSystem typeSystem, XamlLanguageTypeMappings mappings,
             XamlLanguageEmitMappings<IXamlILEmitter, XamlILNodeEmitResult> emitMappings)
         {
-            var so = typeSystem.GetType("System.Object");
+            var so = typeSystem.WellKnownTypes.Object;
             var builder = parentBuilder.DefineSubType(so, "Context", XamlVisibility.Public);
             TypeBuilder = builder;
             
@@ -111,13 +111,13 @@ namespace XamlX.IL
             if (mappings.InnerServiceProviderFactoryMethod != null)
                 InnerServiceProviderField = builder.DefineField(mappings.ServiceProvider, "_innerSp", XamlVisibility.Private, false);
 
-            var staticProvidersField = builder.DefineField(typeSystem.GetType("System.Object").MakeArrayType(1),
+            var staticProvidersField = builder.DefineField(so.MakeArrayType(1),
                 "_staticProviders", XamlVisibility.Private, false);
             
             
-            var systemType = typeSystem.GetType("System.Type");
-            var systemUri = typeSystem.GetType("System.Uri");
-            var systemString = typeSystem.GetType("System.String");
+            var systemType = typeSystem.WellKnownTypes.Type;
+            var systemUri = typeSystem.WellKnownTypes.Uri;
+            var systemString = typeSystem.WellKnownTypes.String;
             var getServiceInterfaceMethod = mappings.ServiceProvider.GetMethod("GetService", so, false, systemType);
 
             var ownServices = new List<IXamlType>();
@@ -173,14 +173,14 @@ namespace XamlX.IL
             if (mappings.ParentStackProvider != null)
             {
                 builder.AddInterfaceImplementation(mappings.ParentStackProvider);
-                var objectListType = typeSystem.GetType("System.Collections.Generic.List`1")
-                    .MakeGenericType(new[] {typeSystem.GetType("System.Object")});
+                var objectListType = typeSystem.WellKnownTypes.ListOfT
+                    .MakeGenericType([typeSystem.WellKnownTypes.Object]);
                 ParentListField = builder.DefineField(objectListType, XamlRuntimeContextDefintion.ParentListFieldName, XamlVisibility.Public, false);
 
                 var enumerator = EmitParentEnumerable(typeSystem, parentBuilder, mappings);
                 CreateCallbacks.Add(enumerator.createCallback);
                 var parentStackEnumerableField = builder.DefineField(
-                    typeSystem.GetType("System.Collections.Generic.IEnumerable`1").MakeGenericType(new[]{so}),
+                    typeSystem.WellKnownTypes.IEnumerableOfT.MakeGenericType([so]),
                     "_parentStackEnumerable", XamlVisibility.Private, false);
 
                 ImplementInterfacePropertyGetter(builder, mappings.ParentStackProvider, "Parents")
@@ -219,7 +219,7 @@ namespace XamlX.IL
                 baseUriField = builder.DefineField(systemUri, "_baseUri", XamlVisibility.Private, false);
                 builder.AddInterfaceImplementation(mappings.UriContextProvider);
                 var getter = builder.DefineMethod(systemUri, Array.Empty<IXamlType>(), "get_BaseUri", XamlVisibility.Public, false, true);
-                var setter = builder.DefineMethod(typeSystem.GetType("System.Void"), new[] {systemUri},
+                var setter = builder.DefineMethod(typeSystem.WellKnownTypes.Void, [systemUri],
                     "set_BaseUri", XamlVisibility.Public, false, true);
 
                 getter.Generator
@@ -267,13 +267,13 @@ namespace XamlX.IL
                     .MarkLabel(next);
 
             }
-            var isAssignableFrom = systemType.GetMethod("IsAssignableFrom", typeSystem.GetType("System.Boolean"),
+            var isAssignableFrom = systemType.GetMethod("IsAssignableFrom", typeSystem.WellKnownTypes.Boolean,
                 false, systemType);
             var fromHandle = systemType.Methods.First(m => m.Name == "GetTypeFromHandle");
             var getTypeFromObject = so.Methods.First(m => m.Name == "GetType" && m.Parameters.Count == 0);
             if (ownServices.Count != 0)
             {
-                var compare = systemType.GetMethod("Equals", typeSystem.GetType("System.Boolean"), false, systemType);
+                var compare = systemType.GetMethod("Equals", typeSystem.WellKnownTypes.Boolean, false, systemType);
 
                 for (var c = 0; c < ownServices.Count; c++)
                 {
@@ -290,7 +290,7 @@ namespace XamlX.IL
                 }
             }
 
-            var staticProviderIndex = getServiceMethod.Generator.DefineLocal(typeSystem.GetType("System.Int32"));
+            var staticProviderIndex = getServiceMethod.Generator.DefineLocal(typeSystem.WellKnownTypes.Int32);
             var staticProviderNext = getServiceMethod.Generator.DefineLabel();
             var staticProviderFailed = getServiceMethod.Generator.DefineLabel();
             var staticProviderEnd = getServiceMethod.Generator.DefineLabel();
@@ -370,10 +370,7 @@ namespace XamlX.IL
                     .Brfalse(noUri)
                     .Emit(OpCodes.Ldarg_0)
                     .Emit(OpCodes.Ldarg_3)
-                    .Newobj(systemUri.GetConstructor(new List<IXamlType>
-                    {
-                        typeSystem.GetType("System.String")
-                    }))
+                    .Newobj(systemUri.GetConstructor([typeSystem.WellKnownTypes.String]))
                     .Emit(OpCodes.Stfld, baseUriField)
                     .MarkLabel(noUri);
             }
@@ -417,10 +414,9 @@ namespace XamlX.IL
             Debug.Assert(ParentListField is not null);
             var parentListField = ParentListField!;
 
-            var @void = ts.GetType("System.Void");
-            var so = ts.GetType("System.Object");
-            var  objectListType = ts.GetType("System.Collections.Generic.List`1")
-                .MakeGenericType(new[] {so});
+            var @void = ts.WellKnownTypes.Void;
+            var so = ts.WellKnownTypes.Object;
+            var objectListType = ts.WellKnownTypes.ListOfT.MakeGenericType([so]);
             
             var pushParentGenerator =
                 builder.DefineMethod(@void, new[] {so}, XamlRuntimeContextDefintion.PushParentMethodName, XamlVisibility.Public, false, false)
@@ -442,7 +438,7 @@ namespace XamlX.IL
             var pop = builder.DefineMethod(@void, Array.Empty<IXamlType>(), XamlRuntimeContextDefintion.PopParentMethodName, XamlVisibility.Public, false, false)
                 .Generator;
 
-            var idx = pop.DefineLocal(ts.GetType("System.Int32"));
+            var idx = pop.DefineLocal(ts.WellKnownTypes.Int32);
             pop
                 // var idx = _parents.Count - 1;
                 .LdThisFld(parentListField)
@@ -513,7 +509,7 @@ namespace XamlX.IL
                         original)
                     .Generator
                     .Emit(OpCodes.Newobj,
-                        typeSystem.GetType("System.NotSupportedException").GetConstructor())
+                        typeSystem.WellKnownTypes.NotSupportedException.GetConstructor())
                     .Emit(OpCodes.Throw);
 
             }
@@ -533,11 +529,9 @@ namespace XamlX.IL
             var parentListField = ParentListField!;
             var parentStackProvider = mappings.ParentStackProvider!;
 
-            var so = typeSystem.GetType("System.Object");
-            var enumerableBuilder =
-                parentBuilder.DefineSubType(typeSystem.GetType("System.Object"), "ParentStackEnumerable", XamlVisibility.Private);
-            var enumerableType = typeSystem.GetType("System.Collections.Generic.IEnumerable`1")
-                .MakeGenericType(new[] {typeSystem.GetType("System.Object")});
+            var so = typeSystem.WellKnownTypes.Object;
+            var enumerableBuilder = parentBuilder.DefineSubType(so, "ParentStackEnumerable", XamlVisibility.Private);
+            var enumerableType = typeSystem.WellKnownTypes.IEnumerableOfT.MakeGenericType([so]);
             enumerableBuilder.AddInterfaceImplementation(enumerableType);
 
             var enumerableParentList =
@@ -558,26 +552,24 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ret);
 
 
-            var enumeratorType = typeSystem.GetType("System.Collections.IEnumerator");
-            var enumeratorObjectType = typeSystem.GetType("System.Collections.Generic.IEnumerator`1")
-                .MakeGenericType(new[] {so});
+            var enumeratorType = typeSystem.WellKnownTypes.IEnumerator;
+            var enumeratorObjectType = typeSystem.WellKnownTypes.IEnumeratorOfT.MakeGenericType([so]);
 
             var enumeratorBuilder = enumerableBuilder.DefineSubType(so, "Enumerator", XamlVisibility.Public);
             enumeratorBuilder.AddInterfaceImplementation(enumeratorObjectType);
 
 
             
-            var state = enumeratorBuilder.DefineField(typeSystem.GetType("System.Int32"), "_state", XamlVisibility.Private, false);
+            var state = enumeratorBuilder.DefineField(typeSystem.WellKnownTypes.Int32, "_state", XamlVisibility.Private, false);
             
             
             var parentList =
                 enumeratorBuilder.DefineField(parentListField.FieldType, "_parentList", XamlVisibility.Private, false);
             var parentProvider =
                 enumeratorBuilder.DefineField(mappings.ServiceProvider, "_parentSP", XamlVisibility.Private, false);
-            var listType = typeSystem.GetType("System.Collections.Generic.List`1")
-                .MakeGenericType(new[] {so});
+            var listType = typeSystem.WellKnownTypes.ListOfT.MakeGenericType([so]);
             var list = enumeratorBuilder.DefineField(listType, "_list", XamlVisibility.Private, false);
-            var listIndex = enumeratorBuilder.DefineField(typeSystem.GetType("System.Int32"), "_listIndex", XamlVisibility.Private, false);
+            var listIndex = enumeratorBuilder.DefineField(typeSystem.WellKnownTypes.Int32, "_listIndex", XamlVisibility.Private, false);
             var current = enumeratorBuilder.DefineField(so, "_current", XamlVisibility.Private, false);
             var parentEnumerator = enumeratorBuilder.DefineField(enumeratorObjectType, "_parentEnumerator", XamlVisibility.Private, false);
             var enumeratorCtor = enumeratorBuilder.DefineConstructor(false, parentList.FieldType, parentProvider.FieldType);
@@ -600,16 +592,17 @@ namespace XamlX.IL
                 .Emit(OpCodes.Ldfld, current)
                 .Emit(OpCodes.Ret);
 
-            enumeratorBuilder.DefineMethod(typeSystem.GetType("System.Void"), Array.Empty<IXamlType>(),
+            enumeratorBuilder.DefineMethod(typeSystem.WellKnownTypes.Void, Array.Empty<IXamlType>(),
                     enumeratorObjectType.FullName + ".Reset", XamlVisibility.Private, false,
                     true, enumeratorObjectType.FindMethod(m => m.Name == "Reset")).Generator
                 .Emit(OpCodes.Newobj,
-                    typeSystem.GetType("System.NotSupportedException").GetConstructor())
+                    typeSystem.WellKnownTypes.NotSupportedException.GetConstructor())
                 .Emit(OpCodes.Throw);
 
-            var disposeGen = enumeratorBuilder.DefineMethod(typeSystem.GetType("System.Void"), Array.Empty<IXamlType>(),
+            var disposeMethod = typeSystem.WellKnownTypes.IDisposable.GetMethod(m => m.Name == "Dispose");
+            var disposeGen = enumeratorBuilder.DefineMethod(typeSystem.WellKnownTypes.Void, Array.Empty<IXamlType>(),
                 "System.IDisposable.Dispose", XamlVisibility.Private, false, true,
-                typeSystem.GetType("System.IDisposable").FindMethod(m => m.Name == "Dispose")).Generator;
+                disposeMethod).Generator;
             var disposeRet = disposeGen.DefineLabel();
             disposeGen
                 .Emit(OpCodes.Ldarg_0)
@@ -617,12 +610,11 @@ namespace XamlX.IL
                 .Emit(OpCodes.Brfalse, disposeRet)
                 .Emit(OpCodes.Ldarg_0)
                 .Emit(OpCodes.Ldfld, parentEnumerator)
-                .Emit(OpCodes.Callvirt, typeSystem.GetType("System.IDisposable").GetMethod(m => m.Name == "Dispose"))
+                .Emit(OpCodes.Callvirt, disposeMethod)
                 .MarkLabel(disposeRet)
                 .Emit(OpCodes.Ret);
 
-            var boolType = typeSystem.GetType("System.Boolean");
-            var moveNext = enumeratorBuilder.DefineMethod(boolType, Array.Empty<IXamlType>(),
+            var moveNext = enumeratorBuilder.DefineMethod(typeSystem.WellKnownTypes.Boolean, [],
                 enumeratorObjectType.FullName+".MoveNext", XamlVisibility.Private,
                 false, true,
                 enumeratorObjectType.GetMethod(m => m.Name == "MoveNext")).Generator;
@@ -669,7 +661,7 @@ namespace XamlX.IL
                 // parentProv = (IParentStackProvider)parent.GetService(typeof(IParentStackProvider));
                 .LdThisFld(parentProvider).Ldtype(parentStackProvider)
                 .EmitCall(mappings.ServiceProvider.GetMethod("GetService", so, false,
-                    typeSystem.GetType("System.Type")))
+                    typeSystem.WellKnownTypes.Type))
                 .Emit(OpCodes.Castclass, parentStackProvider)
                 .Dup().Stloc(parentProv)
                 // if(parentProv == null) goto eof
@@ -684,7 +676,7 @@ namespace XamlX.IL
 
             moveNext.MarkLabel(checkStateParent)
                 // if(!_parentEnumerator.MoveNext()) goto eof
-                .LdThisFld(parentEnumerator).EmitCall(enumeratorType.GetMethod("MoveNext", boolType, false))
+                .LdThisFld(parentEnumerator).EmitCall(enumeratorType.GetMethod("MoveNext", typeSystem.WellKnownTypes.Boolean, false))
                 .Brfalse(eof)
                 // _current = _parentEnumerator.Current
                 .Ldarg_0()
@@ -707,7 +699,7 @@ namespace XamlX.IL
 
             enumerableBuilder.DefineMethod(enumeratorType, Array.Empty<IXamlType>(),
                     "System.Collections.IEnumerable.GetEnumerator", XamlVisibility.Private, false, true,
-                    typeSystem.GetType("System.Collections.IEnumerable").FindMethod(m => m.Name == "GetEnumerator"))
+                    typeSystem.WellKnownTypes.IEnumerable.FindMethod(m => m.Name == "GetEnumerator"))
                 .Generator
                 .Ldarg_0()
                 .EmitCall(createEnumerator)

--- a/src/XamlX/IL/SreTypeSystem.cs
+++ b/src/XamlX/IL/SreTypeSystem.cs
@@ -21,6 +21,8 @@ namespace XamlX.IL
 
         private Dictionary<Type, SreType> _typeDic = new Dictionary<Type, SreType>();
 
+        public XamlTypeWellKnownTypes WellKnownTypes { get; }
+
         public SreTypeSystem()
         {
             // Ensure that System.ComponentModel is available
@@ -35,6 +37,8 @@ namespace XamlX.IL
                 {
                     //
                 }
+
+            WellKnownTypes = new XamlTypeWellKnownTypes(this);
         }
         
         public IXamlAssembly? FindAssembly(string name)

--- a/src/XamlX/IL/XamlILEmitterExtensions.cs
+++ b/src/XamlX/IL/XamlILEmitterExtensions.cs
@@ -181,7 +181,7 @@ namespace XamlX.IL
         [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public static IXamlILEmitter Ldtype(this IXamlILEmitter emitter, IXamlType type)
         {
-            var conv = emitter.TypeSystem.GetType("System.Type")
+            var conv = emitter.TypeSystem.WellKnownTypes.Type
                 .GetMethod(m => m.IsStatic && m.IsPublic && m.Name == "GetTypeFromHandle");
             return emitter.Ldtoken(type).EmitCall(conv);
         }
@@ -189,7 +189,7 @@ namespace XamlX.IL
         [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public static IXamlILEmitter LdMethodInfo(this IXamlILEmitter emitter, IXamlMethod method)
         {
-            var conv = emitter.TypeSystem.GetType("System.Reflection.MethodInfo")
+            var conv = emitter.TypeSystem.WellKnownTypes.MethodInfo
                 .GetMethod(m => m.IsStatic && m.IsPublic && m.Name == "GetMethodFromHandle");
             return emitter.Ldtoken(method).EmitCall(conv);
         }

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -48,7 +48,7 @@ namespace XamlX.Transform
         public IXamlAssembly? DefaultAssembly { get; }
         public XamlLanguageTypeMappings TypeMappings { get; }
         public XamlXmlnsMappings XmlnsMappings { get; }
-        public XamlTypeWellKnownTypes WellKnownTypes { get; }
+        public XamlTypeWellKnownTypes WellKnownTypes => TypeSystem.WellKnownTypes;
         public XamlValueConverter? CustomValueConverter { get; }
         public XamlDiagnosticsHandler DiagnosticsHandler { get; }
         public IXamlIdentifierGenerator IdentifierGenerator { get; }
@@ -67,7 +67,6 @@ namespace XamlX.Transform
             DefaultAssembly = defaultAssembly;
             TypeMappings = typeMappings;
             XmlnsMappings = xmlnsMappings ?? XamlXmlnsMappings.Resolve(typeSystem, typeMappings);
-            WellKnownTypes = new XamlTypeWellKnownTypes(typeSystem);
             CustomValueConverter = customValueConverter;
             DiagnosticsHandler = diagnosticsHandler ?? new XamlDiagnosticsHandler();
             IdentifierGenerator = identifierGenerator ?? new GuidIdentifierGenerator();
@@ -205,87 +204,6 @@ namespace XamlX.Transform
             foreach(var t in types)
             foreach (var a in GetCustomAttribute(prop, t))
                 yield return a;
-        }
-    }
-
-#if !XAMLX_INTERNAL
-    public
-#endif
-    class XamlTypeWellKnownTypes
-    {
-        private readonly IXamlType[] _actionOfT;
-        private readonly IXamlType[] _funcOfT;
-
-        public IXamlType Action { get; }
-        public IXamlType Boolean { get; }
-        public IXamlType CultureInfo { get; }
-        public IXamlType Delegate { get; }
-        public IXamlType DictionaryOfT2 { get; }
-        public IXamlType Double { get; }
-        public IXamlType IEnumerable { get; }
-        public IXamlType IEnumerableOfT { get; }
-        public IXamlType IFormatProvider { get; }
-        public IXamlType IList { get; }
-        public IXamlType IListOfT { get; }
-        public IXamlType IReadOnlyListOfT { get; }
-        public IXamlType Int32 { get; }
-        public IXamlType IntPtr { get; }
-        public IXamlType InvalidCastException { get; }
-        public IXamlType ListOfT { get; }
-        public IXamlType MethodInfo { get; }
-        public IXamlType NullReferenceException { get; }
-        public IXamlType NullableT { get; }
-        public IXamlType Object { get; }
-        public IXamlType ObsoleteAttribute { get; }
-        public IXamlType String { get; }
-        public IXamlType Type { get; }
-        public IXamlType Void { get; }
-        public IXamlType? ExperimentalAttribute { get; }
-
-        public IXamlType GetActionOfT(int typeParamCount)
-            => _actionOfT[typeParamCount - 1];
-
-        public IXamlType GetFuncOfT(int typeParamCount)
-            => _funcOfT[typeParamCount - 1];
-
-        [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = TrimmingMessages.TypeInCoreAssembly)]
-        [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
-        public XamlTypeWellKnownTypes(IXamlTypeSystem typeSystem)
-        {
-            Action = typeSystem.GetType("System.Action");
-            Boolean = typeSystem.GetType("System.Boolean");
-            CultureInfo = typeSystem.GetType("System.Globalization.CultureInfo");
-            Delegate = typeSystem.GetType("System.Delegate");
-            DictionaryOfT2 = typeSystem.GetType("System.Collections.Generic.Dictionary`2");
-            Double = typeSystem.GetType("System.Double");
-            IEnumerable = typeSystem.GetType("System.Collections.IEnumerable");
-            IEnumerableOfT = typeSystem.GetType("System.Collections.Generic.IEnumerable`1");
-            IFormatProvider = typeSystem.GetType("System.IFormatProvider");
-            IList = typeSystem.GetType("System.Collections.IList");
-            IListOfT = typeSystem.GetType("System.Collections.Generic.IList`1");
-            IReadOnlyListOfT = typeSystem.GetType("System.Collections.Generic.IReadOnlyList`1");
-            Int32 = typeSystem.GetType("System.Int32");
-            IntPtr = typeSystem.GetType("System.IntPtr");
-            InvalidCastException = typeSystem.GetType("System.InvalidCastException");
-            ListOfT = typeSystem.GetType("System.Collections.Generic.List`1");
-            MethodInfo = typeSystem.GetType("System.Reflection.MethodInfo");
-            NullReferenceException = typeSystem.GetType("System.NullReferenceException");
-            NullableT = typeSystem.GetType("System.Nullable`1");
-            Object = typeSystem.GetType("System.Object");
-            ObsoleteAttribute = typeSystem.GetType("System.ObsoleteAttribute");
-            String = typeSystem.GetType("System.String");
-            Type = typeSystem.GetType("System.Type");
-            Void = typeSystem.GetType("System.Void");
-
-            _actionOfT = new IXamlType[16];
-            for (var i = 1; i <= 16; ++i)
-                _actionOfT[i - 1] = typeSystem.GetType($"System.Action`{i}");
-
-            _funcOfT = new IXamlType[17];
-            for (var i = 1; i <= 17; ++i)
-                _funcOfT[i - 1] = typeSystem.GetType($"System.Func`{i}");
-
-            ExperimentalAttribute = typeSystem.FindType("System.Diagnostics.CodeAnalysis.ExperimentalAttribute");
         }
     }
 }

--- a/src/XamlX/Transform/TransformerConfiguration.cs
+++ b/src/XamlX/Transform/TransformerConfiguration.cs
@@ -213,41 +213,78 @@ namespace XamlX.Transform
 #endif
     class XamlTypeWellKnownTypes
     {
-        public IXamlType IList { get; }
-        public IXamlType IEnumerable { get; }
-        public IXamlType IEnumerableT { get; }
-        public IXamlType IListOfT { get; }
-        public IXamlType Object { get; }
-        public IXamlType String { get; }
-        public IXamlType Int32 { get; }
-        public IXamlType Void { get; }
+        private readonly IXamlType[] _actionOfT;
+        private readonly IXamlType[] _funcOfT;
+
+        public IXamlType Action { get; }
         public IXamlType Boolean { get; }
-        public IXamlType Double { get; }
-        public IXamlType NullableT { get; }
         public IXamlType CultureInfo { get; }
-        public IXamlType IFormatProvider { get; }
         public IXamlType Delegate { get; }
+        public IXamlType DictionaryOfT2 { get; }
+        public IXamlType Double { get; }
+        public IXamlType IEnumerable { get; }
+        public IXamlType IEnumerableOfT { get; }
+        public IXamlType IFormatProvider { get; }
+        public IXamlType IList { get; }
+        public IXamlType IListOfT { get; }
+        public IXamlType IReadOnlyListOfT { get; }
+        public IXamlType Int32 { get; }
+        public IXamlType IntPtr { get; }
+        public IXamlType InvalidCastException { get; }
+        public IXamlType ListOfT { get; }
+        public IXamlType MethodInfo { get; }
+        public IXamlType NullReferenceException { get; }
+        public IXamlType NullableT { get; }
+        public IXamlType Object { get; }
         public IXamlType ObsoleteAttribute { get; }
+        public IXamlType String { get; }
+        public IXamlType Type { get; }
+        public IXamlType Void { get; }
         public IXamlType? ExperimentalAttribute { get; }
 
+        public IXamlType GetActionOfT(int typeParamCount)
+            => _actionOfT[typeParamCount - 1];
+
+        public IXamlType GetFuncOfT(int typeParamCount)
+            => _funcOfT[typeParamCount - 1];
+
+        [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = TrimmingMessages.TypeInCoreAssembly)]
         [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
         public XamlTypeWellKnownTypes(IXamlTypeSystem typeSystem)
         {
-            Void = typeSystem.GetType("System.Void");
-            String = typeSystem.GetType("System.String");
-            Int32 = typeSystem.GetType("System.Int32");
-            Object = typeSystem.GetType("System.Object");
+            Action = typeSystem.GetType("System.Action");
             Boolean = typeSystem.GetType("System.Boolean");
-            Double = typeSystem.GetType("System.Double");
             CultureInfo = typeSystem.GetType("System.Globalization.CultureInfo");
+            Delegate = typeSystem.GetType("System.Delegate");
+            DictionaryOfT2 = typeSystem.GetType("System.Collections.Generic.Dictionary`2");
+            Double = typeSystem.GetType("System.Double");
+            IEnumerable = typeSystem.GetType("System.Collections.IEnumerable");
+            IEnumerableOfT = typeSystem.GetType("System.Collections.Generic.IEnumerable`1");
             IFormatProvider = typeSystem.GetType("System.IFormatProvider");
             IList = typeSystem.GetType("System.Collections.IList");
-            IEnumerable = typeSystem.GetType("System.Collections.IEnumerable");
             IListOfT = typeSystem.GetType("System.Collections.Generic.IList`1");
-            IEnumerableT = typeSystem.GetType("System.Collections.Generic.IEnumerable`1");
+            IReadOnlyListOfT = typeSystem.GetType("System.Collections.Generic.IReadOnlyList`1");
+            Int32 = typeSystem.GetType("System.Int32");
+            IntPtr = typeSystem.GetType("System.IntPtr");
+            InvalidCastException = typeSystem.GetType("System.InvalidCastException");
+            ListOfT = typeSystem.GetType("System.Collections.Generic.List`1");
+            MethodInfo = typeSystem.GetType("System.Reflection.MethodInfo");
+            NullReferenceException = typeSystem.GetType("System.NullReferenceException");
             NullableT = typeSystem.GetType("System.Nullable`1");
-            Delegate = typeSystem.GetType("System.Delegate");
+            Object = typeSystem.GetType("System.Object");
             ObsoleteAttribute = typeSystem.GetType("System.ObsoleteAttribute");
+            String = typeSystem.GetType("System.String");
+            Type = typeSystem.GetType("System.Type");
+            Void = typeSystem.GetType("System.Void");
+
+            _actionOfT = new IXamlType[16];
+            for (var i = 1; i <= 16; ++i)
+                _actionOfT[i - 1] = typeSystem.GetType($"System.Action`{i}");
+
+            _funcOfT = new IXamlType[17];
+            for (var i = 1; i <= 17; ++i)
+                _funcOfT[i - 1] = typeSystem.GetType($"System.Func`{i}");
+
             ExperimentalAttribute = typeSystem.FindType("System.Diagnostics.CodeAnalysis.ExperimentalAttribute");
         }
     }

--- a/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
+++ b/src/XamlX/Transform/Transformers/XamlIntrinsicsTransformer.cs
@@ -58,7 +58,7 @@ namespace XamlX.Transform.Transformers
 
                     return new XamlTypeExtensionNode(node,
                         new XamlAstXmlTypeReference(textNode, resolvedNs, pair[1], xml.GenericArguments),
-                        context.Configuration.TypeSystem.GetType("System.Type"));
+                        context.Configuration.WellKnownTypes.Type);
                 }
 
                 if (xml.Name == "Static")

--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -30,7 +30,7 @@ namespace XamlX.Transform
                 var actualType = type;
                 if (actualType.Equals(known.IEnumerable))
                     actualType = known.IList;
-                if (actualType.GenericTypeDefinition?.Equals(known.IEnumerableT) == true)
+                if (actualType.GenericTypeDefinition?.Equals(known.IEnumerableOfT) == true)
                     actualType = known.IListOfT.MakeGenericType(actualType.GenericArguments[0]);
 
                 var inspectTypes = new List<IXamlType>();

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -151,6 +151,7 @@ namespace XamlX.TypeSystem
     interface IXamlTypeSystem
     {
         IEnumerable<IXamlAssembly> Assemblies { get; }
+        XamlTypeWellKnownTypes WellKnownTypes { get; }
         IXamlAssembly? FindAssembly(string substring);
         IXamlType? FindType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] string name);
         IXamlType? FindType([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] string name, string assembly);

--- a/src/XamlX/TypeSystem/XamlTypeWellKnownTypes.cs
+++ b/src/XamlX/TypeSystem/XamlTypeWellKnownTypes.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace XamlX.TypeSystem;
+
+#if !XAMLX_INTERNAL
+public
+#endif
+class XamlTypeWellKnownTypes
+{
+    private readonly IXamlType[] _actionOfT;
+    private readonly IXamlType[] _funcOfT;
+
+    public IXamlType Action { get; }
+    public IXamlType Array { get; }
+    public IXamlType Boolean { get; }
+    public IXamlType CultureInfo { get; }
+    public IXamlType Delegate { get; }
+    public IXamlType DictionaryOfT2 { get; }
+    public IXamlType Double { get; }
+    public IXamlType IDisposable { get; }
+    public IXamlType IEnumerable { get; }
+    public IXamlType IEnumerableOfT { get; }
+    public IXamlType IEnumerator { get; }
+    public IXamlType IEnumeratorOfT { get; }
+    public IXamlType IFormatProvider { get; }
+    public IXamlType IList { get; }
+    public IXamlType IListOfT { get; }
+    public IXamlType IReadOnlyListOfT { get; }
+    public IXamlType Int32 { get; }
+    public IXamlType IntPtr { get; }
+    public IXamlType InvalidCastException { get; }
+    public IXamlType ListOfT { get; }
+    public IXamlType MethodInfo { get; }
+    public IXamlType MulticastDelegate { get; }
+    public IXamlType NotSupportedException { get; }
+    public IXamlType NullReferenceException { get; }
+    public IXamlType NullableT { get; }
+    public IXamlType Object { get; }
+    public IXamlType ObsoleteAttribute { get; }
+    public IXamlType String { get; }
+    public IXamlType Type { get; }
+    public IXamlType Uri { get; }
+    public IXamlType Void { get; }
+    public IXamlType? ExperimentalAttribute { get; }
+
+    public IXamlType GetActionOfT(int typeParamCount)
+        => _actionOfT[typeParamCount - 1];
+
+    public IXamlType GetFuncOfT(int typeParamCount)
+        => _funcOfT[typeParamCount - 1];
+
+    [UnconditionalSuppressMessage("Trimming", "IL2062", Justification = TrimmingMessages.TypeInCoreAssembly)]
+    [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
+    public XamlTypeWellKnownTypes(IXamlTypeSystem typeSystem)
+    {
+        Action = typeSystem.GetType("System.Action");
+        Array = typeSystem.GetType("System.Array");
+        Boolean = typeSystem.GetType("System.Boolean");
+        CultureInfo = typeSystem.GetType("System.Globalization.CultureInfo");
+        Delegate = typeSystem.GetType("System.Delegate");
+        DictionaryOfT2 = typeSystem.GetType("System.Collections.Generic.Dictionary`2");
+        Double = typeSystem.GetType("System.Double");
+        IDisposable = typeSystem.GetType("System.IDisposable");
+        IEnumerable = typeSystem.GetType("System.Collections.IEnumerable");
+        IEnumerableOfT = typeSystem.GetType("System.Collections.Generic.IEnumerable`1");
+        IEnumerator = typeSystem.GetType("System.Collections.IEnumerator");
+        IEnumeratorOfT = typeSystem.GetType("System.Collections.Generic.IEnumerator`1");
+        IFormatProvider = typeSystem.GetType("System.IFormatProvider");
+        IList = typeSystem.GetType("System.Collections.IList");
+        IListOfT = typeSystem.GetType("System.Collections.Generic.IList`1");
+        IReadOnlyListOfT = typeSystem.GetType("System.Collections.Generic.IReadOnlyList`1");
+        Int32 = typeSystem.GetType("System.Int32");
+        IntPtr = typeSystem.GetType("System.IntPtr");
+        InvalidCastException = typeSystem.GetType("System.InvalidCastException");
+        ListOfT = typeSystem.GetType("System.Collections.Generic.List`1");
+        MethodInfo = typeSystem.GetType("System.Reflection.MethodInfo");
+        MulticastDelegate = typeSystem.GetType("System.MulticastDelegate");
+        NotSupportedException = typeSystem.GetType("System.NotSupportedException");
+        NullReferenceException = typeSystem.GetType("System.NullReferenceException");
+        NullableT = typeSystem.GetType("System.Nullable`1");
+        Object = typeSystem.GetType("System.Object");
+        ObsoleteAttribute = typeSystem.GetType("System.ObsoleteAttribute");
+        String = typeSystem.GetType("System.String");
+        Type = typeSystem.GetType("System.Type");
+        Uri = typeSystem.GetType("System.Uri");
+        Void = typeSystem.GetType("System.Void");
+
+        _actionOfT = new IXamlType[16];
+        for (var i = 1; i <= 16; ++i)
+            _actionOfT[i - 1] = typeSystem.GetType($"System.Action`{i}");
+
+        _funcOfT = new IXamlType[17];
+        for (var i = 1; i <= 17; ++i)
+            _funcOfT[i - 1] = typeSystem.GetType($"System.Func`{i}");
+
+        ExperimentalAttribute = typeSystem.FindType("System.Diagnostics.CodeAnalysis.ExperimentalAttribute");
+    }
+}


### PR DESCRIPTION
This PR improves the caching of `IXamlType` instances in several ways:
 - The well-known types are now part of the `IXamlTypeSystem` itself, meaning we can use them in places where we don't have the full transformation context.
 - All used types in the compiler are part of `XamlTypeWellKnownTypes`, to avoid any extra lookup (even cached). All call sites using explicit `GetType()` calls have been adjusted.
- Finally, `CecilAssembly.FindType` is fixed: the old code was looking up types by their full name, but caching them by their short name, meaning the cache didn't hit anything at all... 