### PR TITLE
Misc performance improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+</Project>

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -14,6 +14,11 @@ namespace XamlX.TypeSystem
         internal class CecilType : IXamlType, ITypeReference
         {
             private readonly CecilAssembly? _assembly;
+
+            // Cache Reference.MetadataType. It's a virtual call that shows a up in performance snapshots.
+            // Its called *a lot* by Equals().
+            private readonly MetadataType _metadataType;
+
             public CecilTypeSystem TypeSystem { get; }
             public TypeReference Reference { get; }
             public TypeDefinition Definition { get; }
@@ -23,7 +28,6 @@ namespace XamlX.TypeSystem
             public CecilType(CecilTypeResolveContext parentTypeResolveContext, CecilAssembly? assembly, TypeDefinition definition)
                 : this(parentTypeResolveContext, assembly, definition, definition)
             {
-                
             }
 
             [UnconditionalSuppressMessage("Trimming", "IL2122", Justification = TrimmingMessages.TypeInCoreAssembly)]
@@ -31,6 +35,7 @@ namespace XamlX.TypeSystem
                 TypeReference reference)
             {
                 _assembly = assembly;
+                _metadataType = reference.MetadataType;
                 TypeSystem = parentTypeResolveContext.TypeSystem;
                 Reference = reference;
                 Definition = definition;
@@ -183,12 +188,15 @@ namespace XamlX.TypeSystem
             {
                 if (!(other is CecilType o))
                     return false;
-                return TypeReferenceEqualityComparer.AreEqual(Reference, o.Reference, CecilTypeComparisonMode.Exact);
+
+                return TypeReferenceEqualityComparer.AreEqual(
+                    Reference, _metadataType, o.Reference, o._metadataType, CecilTypeComparisonMode.Exact);
             }
 
             public override bool Equals(object? other) => Equals(other as IXamlType);
 
-            public override int GetHashCode() => TypeReferenceEqualityComparer.GetHashCodeFor(Reference, CecilTypeComparisonMode.Exact);
+            public override int GetHashCode()
+                => TypeReferenceEqualityComparer.GetHashCodeFor(Reference, _metadataType, CecilTypeComparisonMode.Exact);
 
             public override string ToString() => Definition.ToString();
         }

--- a/src/XamlX.IL.Cecil/CecilType.cs
+++ b/src/XamlX.IL.Cecil/CecilType.cs
@@ -104,13 +104,11 @@ namespace XamlX.TypeSystem
             bool IsAssignableFromCore(IXamlType type)
             {
                 if (type == XamlPseudoType.Null)
-                    return !IsValueType || GenericTypeDefinition?.FullName == "System.Nullable`1";
+                    return !IsValueType || this.IsNullable();
 
-                if (type.IsValueType 
-                    && GenericTypeDefinition?.FullName == "System.Nullable`1"
-                    && GenericArguments[0].Equals(type))
+                if (type.IsValueType && this.IsNullableOf(type))
                     return true;
-                if (FullName == "System.Object" && type.IsInterface)
+                if (this.Is("System", "Object") && type.IsInterface)
                     return true;
                 var baseType = type;
                 while (baseType != null)

--- a/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
@@ -39,101 +39,52 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 		var aMetadataType = a.MetadataType;
 		var bMetadataType = b.MetadataType;
 
-		if (aMetadataType == MetadataType.GenericInstance || bMetadataType == MetadataType.GenericInstance)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
+		if (aMetadataType != bMetadataType)
+			return false;
 
-			return AreEqual((GenericInstanceType)a, (GenericInstanceType)b, comparisonMode);
+		switch (aMetadataType)
+		{
+			case MetadataType.GenericInstance:
+				return AreEqual((GenericInstanceType)a, (GenericInstanceType)b, comparisonMode);
+			case MetadataType.Array:
+			{
+				var a1 = (ArrayType)a;
+				var b1 = (ArrayType)b;
+				if (a1.Rank != b1.Rank)
+					return false;
+
+				return AreEqual(a1.ElementType, b1.ElementType, comparisonMode);
+			}
+			case MetadataType.Var:
+			case MetadataType.MVar:
+				return AreEqual((GenericParameter)a, (GenericParameter)b, comparisonMode);
+			case MetadataType.ByReference:
+				return AreEqual(((ByReferenceType)a).ElementType, ((ByReferenceType)b).ElementType, comparisonMode);
+			case MetadataType.Pointer:
+				return AreEqual(((PointerType)a).ElementType, ((PointerType)b).ElementType, comparisonMode);
+			case MetadataType.RequiredModifier:
+			{
+				var a1 = (RequiredModifierType)a;
+				var b1 = (RequiredModifierType)b;
+
+				return AreEqual(a1.ModifierType, b1.ModifierType, comparisonMode) &&
+				       AreEqual(a1.ElementType, b1.ElementType, comparisonMode);
+			}
+			case MetadataType.OptionalModifier:
+			{
+				var a1 = (OptionalModifierType)a;
+				var b1 = (OptionalModifierType)b;
+
+				return AreEqual(a1.ModifierType, b1.ModifierType, comparisonMode) &&
+				       AreEqual(a1.ElementType, b1.ElementType, comparisonMode);
+			}
+			case MetadataType.Pinned:
+				return AreEqual(((PinnedType)a).ElementType, ((PinnedType)b).ElementType, comparisonMode);
+			case MetadataType.Sentinel:
+				return AreEqual(((SentinelType)a).ElementType, ((SentinelType)b).ElementType, comparisonMode);
 		}
 
-		if (aMetadataType == MetadataType.Array || bMetadataType == MetadataType.Array)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			var a1 = (ArrayType)a;
-			var b1 = (ArrayType)b;
-			if (a1.Rank != b1.Rank)
-				return false;
-
-			return AreEqual(a1.ElementType, b1.ElementType, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.Var || bMetadataType == MetadataType.Var)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			return AreEqual((GenericParameter)a, (GenericParameter)b, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.MVar || bMetadataType == MetadataType.MVar)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			return AreEqual((GenericParameter)a, (GenericParameter)b, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.ByReference || bMetadataType == MetadataType.ByReference)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			return AreEqual(((ByReferenceType)a).ElementType, ((ByReferenceType)b).ElementType, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.Pointer || bMetadataType == MetadataType.Pointer)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			return AreEqual(((PointerType)a).ElementType, ((PointerType)b).ElementType, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.RequiredModifier || bMetadataType == MetadataType.RequiredModifier)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			var a1 = (RequiredModifierType)a;
-			var b1 = (RequiredModifierType)b;
-
-			return AreEqual(a1.ModifierType, b1.ModifierType, comparisonMode) &&
-			       AreEqual(a1.ElementType, b1.ElementType, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.OptionalModifier || bMetadataType == MetadataType.OptionalModifier)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			var a1 = (OptionalModifierType)a;
-			var b1 = (OptionalModifierType)b;
-
-			return AreEqual(a1.ModifierType, b1.ModifierType, comparisonMode) &&
-			       AreEqual(a1.ElementType, b1.ElementType, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.Pinned || bMetadataType == MetadataType.Pinned)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			return AreEqual(((PinnedType)a).ElementType, ((PinnedType)b).ElementType, comparisonMode);
-		}
-
-		if (aMetadataType == MetadataType.Sentinel || bMetadataType == MetadataType.Sentinel)
-		{
-			if (aMetadataType != bMetadataType)
-				return false;
-
-			return AreEqual(((SentinelType)a).ElementType, ((SentinelType)b).ElementType, comparisonMode);
-		}
-
-		if (!a.Name.Equals(b.Name, StringComparison.Ordinal) ||
-			!a.Namespace.Equals(b.Namespace, StringComparison.Ordinal))
+		if (a.Name != b.Name || a.Namespace != b.Namespace)
 			return false;
 
 		var xDefinition = comparisonMode == CecilTypeComparisonMode.Exact ? a.Resolve() : a as TypeDefinition;

--- a/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
+++ b/src/XamlX.IL.Cecil/Comparers/TypeReferenceEqualityComparer.cs
@@ -27,18 +27,26 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 		return GetHashCodeFor(obj, _comparisonMode);
 	}
 
-	public static bool AreEqual(TypeReference? a, TypeReference? b,
-		CecilTypeComparisonMode comparisonMode)
+	public static bool AreEqual(TypeReference? a, TypeReference? b, CecilTypeComparisonMode comparisonMode)
 	{
 		if (ReferenceEquals(a, b))
 			return true;
 
-		if (a == null || b == null)
+		if (a is null || b is null)
 			return false;
 
-		var aMetadataType = a.MetadataType;
-		var bMetadataType = b.MetadataType;
+		return AreEqual(a, a.MetadataType, b, b.MetadataType, comparisonMode);
+	}
 
+	// Version that takes the metadata types directly for performance reasons.
+	// Read the comment on CecilType._metadataType for more information.
+	public static bool AreEqual(
+		TypeReference a,
+		MetadataType aMetadataType,
+		TypeReference b,
+		MetadataType bMetadataType,
+		CecilTypeComparisonMode comparisonMode)
+	{
 		if (aMetadataType != bMetadataType)
 			return false;
 
@@ -150,6 +158,9 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 	}
 
 	public static int GetHashCodeFor(TypeReference obj, CecilTypeComparisonMode comparisonMode)
+		=> GetHashCodeFor(obj, obj.MetadataType, comparisonMode);
+
+	public static int GetHashCodeFor(TypeReference obj, MetadataType metadataType, CecilTypeComparisonMode comparisonMode)
 	{
 		// a very good prime number
 		const int hashCodeMultiplier = 486187739;
@@ -163,8 +174,6 @@ internal sealed class TypeReferenceEqualityComparer : EqualityComparer<TypeRefer
 		const int sentinelMultiplier = 59;
 		const int moduleMultiplier = 61;
 		const int assemblyMultiplier = 67;
-
-		var metadataType = obj.MetadataType;
 
 		if (metadataType == MetadataType.GenericInstance)
 		{

--- a/src/XamlX/Ast/Clr.cs
+++ b/src/XamlX/Ast/Clr.cs
@@ -808,7 +808,7 @@ namespace XamlX.Ast
 
         private static bool IsFunctionPointerLike(IXamlType xamlType)
             => xamlType.IsFunctionPointer // Cecil, SRE with .NET 8
-               || xamlType.FullName == "System.IntPtr"; // SRE with .NET < 8 or .NET Standard
+               || xamlType.Is("System", "IntPtr"); // SRE with .NET < 8 or .NET Standard
 
         private sealed class XamlClosureInfo
         {

--- a/src/XamlX/Ast/Common.cs
+++ b/src/XamlX/Ast/Common.cs
@@ -115,7 +115,8 @@ namespace XamlX.Ast
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static void VisitList<T>(List<T> list, Visitor visitor) where T : IXamlAstNode
         {
-            for (var c = 0; c < list.Count; c++)
+            var count = list.Count;
+            for (var c = 0; c < count; c++)
             {
                 list[c] = (T) list[c].Visit(visitor);
             }
@@ -124,7 +125,8 @@ namespace XamlX.Ast
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected static void VisitList<T>(T[] list, Visitor visitor) where T : IXamlAstNode
         {
-            for (var c = 0; c < list.Length; c++)
+            var length = list.Length;
+            for (var c = 0; c < length; c++)
             {
                 list[c] = (T) list[c].Visit(visitor);
             }

--- a/src/XamlX/Ast/Common.cs
+++ b/src/XamlX/Ast/Common.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using XamlX.TypeSystem;
 using Visitor = XamlX.Ast.IXamlAstVisitor;
 
@@ -29,6 +30,7 @@ namespace XamlX.Ast
 #endif
     interface IXamlAstNode : IXamlLineInfo
     {
+        bool IsSkipped { get; }
         void VisitChildren(Visitor visitor);
         IXamlAstNode Visit(Visitor visitor);
     }
@@ -36,18 +38,13 @@ namespace XamlX.Ast
 #if !XAMLX_INTERNAL
     public
 #endif
-    interface ISkipXamlAstNode : IXamlAstNode
-    {
-    }
-
-#if !XAMLX_INTERNAL
-    public
-#endif
-    class SkipXamlAstNode : XamlAstNode, ISkipXamlAstNode, IXamlAstValueNode, IXamlAstManipulationNode
+    class SkipXamlAstNode : XamlAstNode, IXamlAstValueNode, IXamlAstManipulationNode
     {
         public SkipXamlAstNode(IXamlLineInfo lineInfo) : base(lineInfo)
         {
         }
+
+        public override bool IsSkipped => true;
 
         public IXamlAstTypeReference Type => new XamlAstClrTypeReference(this, XamlPseudoType.Unknown, false);
 
@@ -57,11 +54,13 @@ namespace XamlX.Ast
 #if !XAMLX_INTERNAL
     public
 #endif
-    class SkipXamlValueWithManipulationNode : XamlValueWithManipulationNode, ISkipXamlAstNode, IXamlAstManipulationNode
+    class SkipXamlValueWithManipulationNode : XamlValueWithManipulationNode, IXamlAstManipulationNode
     {
         public SkipXamlValueWithManipulationNode(IXamlLineInfo lineInfo) : base(lineInfo, new SkipXamlAstNode(lineInfo), null)
         {
         }
+
+        public override bool IsSkipped => true;
 
         public override void VisitChildren(Visitor visitor) { }
     }
@@ -71,6 +70,7 @@ namespace XamlX.Ast
 #endif
     abstract class XamlAstNode : IXamlAstNode
     {
+        public virtual bool IsSkipped => false;
         public int Line { get; set; }
         public int Position { get; set; }
 
@@ -84,10 +84,10 @@ namespace XamlX.Ast
         {
             
         }
-        
+
         public IXamlAstNode Visit(Visitor visitor)
         {
-            if (this is ISkipXamlAstNode)
+            if (IsSkipped)
             {
                 return this;
             }
@@ -112,9 +112,19 @@ namespace XamlX.Ast
             return node;
         }
 
-        protected static void VisitList<T>(IList<T> list, Visitor visitor) where T : IXamlAstNode
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static void VisitList<T>(List<T> list, Visitor visitor) where T : IXamlAstNode
         {
             for (var c = 0; c < list.Count; c++)
+            {
+                list[c] = (T) list[c].Visit(visitor);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static void VisitList<T>(T[] list, Visitor visitor) where T : IXamlAstNode
+        {
+            for (var c = 0; c < list.Length; c++)
             {
                 list[c] = (T) list[c].Visit(visitor);
             }

--- a/src/XamlX/IL/CheckingIlEmitter.cs
+++ b/src/XamlX/IL/CheckingIlEmitter.cs
@@ -137,7 +137,7 @@ namespace XamlX.IL
             var stackBalance = 0;
             if (method != null && (code == OpCodes.Call || code == OpCodes.Callvirt))
             {
-                if (method.ReturnType.FullName != "System.Void")
+                if (!method.ReturnType.Is("System", "Void"))
                     stackBalance += 1;
             }
             else if (ctor!= null && (code == OpCodes.Call  || code == OpCodes.Newobj))

--- a/src/XamlX/IL/XamlILEmitterExtensions.cs
+++ b/src/XamlX/IL/XamlILEmitterExtensions.cs
@@ -232,15 +232,18 @@ namespace XamlX.IL
                 return emitter.Ldnull();
             }
 
-            return type.FullName switch
+            if (type.Namespace != "System")
+                return EmitNewStruct(emitter, type);
+
+            return type.Name switch
             {
-                "System.Boolean" or "System.Char" or "System.Int32" or "System.UInt32"
-                    or "System.Byte" or "System.SByte" or "System.Int16" or "System.UInt16"
-                    or "System.IntPtr" or "System.UIntPtr" => emitter.Emit(OpCodes.Ldc_I4_0),
-                "System.Int64" or "System.UInt64" => emitter.Emit(OpCodes.Ldc_I8, 0L),
-                "System.Single" => emitter.Emit(OpCodes.Ldc_R4, 0F),
-                "System.Double" => emitter.Emit(OpCodes.Ldc_R8, 0D),
-                "System.Decimal" => emitter.Ldsfld(type.Fields.First(f => f.Name == "Zero")),
+                "Boolean" or "Char" or "Int32" or "UInt32"
+                    or "Byte" or "SByte" or "Int16" or "UInt16"
+                    or "IntPtr" or "UIntPtr" => emitter.Emit(OpCodes.Ldc_I4_0),
+                "Int64" or "UInt64" => emitter.Emit(OpCodes.Ldc_I8, 0L),
+                "Single" => emitter.Emit(OpCodes.Ldc_R4, 0F),
+                "Double" => emitter.Emit(OpCodes.Ldc_R8, 0D),
+                "Decimal" => emitter.Ldsfld(type.Fields.First(f => f.Name == "Zero")),
                 _ => EmitNewStruct(emitter, type)
             };
 

--- a/src/XamlX/Transform/AstTransformationContext.cs
+++ b/src/XamlX/Transform/AstTransformationContext.cs
@@ -68,14 +68,20 @@ namespace XamlX.Transform
                 try
                 {
                     var outputNode = VisitCore(_context, node);
-                    if (outputNode is null)
-                    {
-                        throw new InvalidOperationException(
-                            $"\"{GetTransformerInfo()}\" returned null IXamlAstNode.");
-                    }
-                    return outputNode;
+                    return outputNode ?? throw CreateTransformerException();
                 }
                 catch (Exception e)
+                {
+                    return ExceptionHandler(e);
+                }
+
+                InvalidOperationException CreateTransformerException()
+                {
+                    return new InvalidOperationException(
+                        $"\"{GetTransformerInfo()}\" returned null IXamlAstNode.");
+                }
+
+                IXamlAstNode ExceptionHandler(Exception e)
                 {
                     var reportException = e is XmlException
                         ? e
@@ -85,7 +91,7 @@ namespace XamlX.Transform
                         {
                             Document = _context.Document
                         };
-                    
+
                     if (_context.OnUnhandledTransformError(reportException))
                     {
                         return node is IXamlAstTypeReference
@@ -95,8 +101,8 @@ namespace XamlX.Transform
                     else
                     {
 #if DEBUG
-                        throw;
-#else 
+                        throw e;
+#else
                         throw reportException;
 #endif
                     }

--- a/src/XamlX/Transform/XamlContextBase.cs
+++ b/src/XamlX/Transform/XamlContextBase.cs
@@ -11,7 +11,7 @@ namespace XamlX.Transform
     class XamlContextBase
     {
         private readonly Dictionary<Type, object> _items = new();
-        private readonly List<IXamlAstNode> _parentNodes = [];
+        private readonly List<IXamlAstNode> _parentNodes = new(16);
         
         public T GetItem<T>() where T : notnull => (T)_items[typeof(T)];
 

--- a/src/XamlX/Transform/XamlTransformHelpers.cs
+++ b/src/XamlX/Transform/XamlTransformHelpers.cs
@@ -293,7 +293,7 @@ namespace XamlX.Transform
                     return true;
                 }
 
-                if (type.FullName == "System.Type")
+                if (type.Is("System", "Type"))
                 {
                     var resolvedType = TypeReferenceResolver.ResolveType(context, tn.Text, false, tn, true);
                     rv = new XamlTypeExtensionNode(tn, resolvedType, type);

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -602,6 +602,9 @@ namespace XamlX.TypeSystem
             lst.Insert(0, method.DeclaringType);
             return lst;
         }
+
+        public static bool Is(this IXamlType type, string ns, string name)
+            => type.Name == name && type.Namespace == ns;
     }
 
 }

--- a/src/XamlX/TypeSystem/TypeSystem.cs
+++ b/src/XamlX/TypeSystem/TypeSystem.cs
@@ -365,17 +365,17 @@ namespace XamlX.TypeSystem
         
         public static IEnumerable<IXamlMethod> FindMethods(this IXamlType type, Func<IXamlMethod, bool> criteria)
         {
-            foreach (var m in type.Methods)
-                if (criteria(m))
-                    yield return m;
-            var bt = type.BaseType;
-            if(bt!=null)
-                foreach (var bm in bt.FindMethods(criteria))
-                    yield return bm;
-            foreach(var iface in type.Interfaces)
-            foreach(var m in iface.Methods)
-                if (criteria(m))
-                    yield return m;
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var method in t.Methods)
+                    if (criteria(method))
+                        yield return method;
+            }
+
+            foreach (var iface in type.Interfaces)
+                foreach (var method in iface.Methods)
+                    if (criteria(method))
+                        yield return method;
         }
 
         public static IXamlMethod GetMethod(this IXamlType type, Func<IXamlMethod, bool> criteria)
@@ -384,19 +384,20 @@ namespace XamlX.TypeSystem
 
         public static IXamlMethod? FindMethod(this IXamlType type, Func<IXamlMethod, bool> criteria)
         {
-            foreach (var m in type.Methods)
-                if (criteria(m))
-                    return m;
-            var bres = type.BaseType?.FindMethod(criteria);
-            if (bres != null)
-                return bres;
-            foreach(var iface in type.Interfaces)
-                foreach(var m in iface.Methods)
-                    if (criteria(m))
-                        return m;
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var method in t.Methods)
+                    if (criteria(method))
+                        return method;
+            }
+
+            foreach (var iface in type.Interfaces)
+                foreach (var method in iface.Methods)
+                    if (criteria(method))
+                        return method;
+
             return null;
         }
-
 
         public static IXamlMethod GetMethod(
             this IXamlType type,
@@ -521,7 +522,7 @@ namespace XamlX.TypeSystem
         {
             var def = type.GenericTypeDefinition;
             if (def == null) return false;
-            return def.Namespace == "System" && def.Name == "Nullable`1";
+            return def.Is("System", "Nullable`1");
         }
 
         public static bool IsNullableOf(this IXamlType type, IXamlType vtype)
@@ -534,54 +535,57 @@ namespace XamlX.TypeSystem
 
         public static IEnumerable<IXamlType> GetAllInterfaces(this IXamlType type)
         {
-            foreach (var i in type.Interfaces)
-                yield return i;
-            if(type.BaseType!=null)
-                foreach (var i in type.BaseType.GetAllInterfaces())
-                    yield return i;
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var iface in t.Interfaces)
+                    yield return iface;
+            }
         }
 
         public static IEnumerable<IXamlCustomAttribute> GetAllCustomAttributes(this IXamlType type)
         {
-            foreach (var i in type.CustomAttributes)
-                yield return i;
-            if(type.BaseType!=null)
-                foreach (var i in type.BaseType.GetAllCustomAttributes())
+            foreach (var attribute in type.CustomAttributes)
+                yield return attribute;
+
+            for (var t = type.BaseType; t is not null; t = t.BaseType)
+            {
+                foreach (var attribute in t.CustomAttributes)
                 {
-                    var usageAttribute = i.Type.CustomAttributes.FirstOrDefault(a => a.Type.FullName == "System.AttributeUsageAttribute");
+                    var usageAttribute = attribute.Type.CustomAttributes.FirstOrDefault(a => a.Type.Name == "AttributeUsageAttribute" && a.Type.Namespace == "System");
                     if (usageAttribute is null
                         || (usageAttribute.Properties.TryGetValue("Inherited", out var boolean) && boolean is true))
                     {
-                        yield return i;
+                        yield return attribute;
                     }
                 }
+            }
         }
 
-        public static IEnumerable<IXamlProperty> GetAllProperties(this IXamlType t)
+        public static IEnumerable<IXamlProperty> GetAllProperties(this IXamlType type)
         {
-            foreach (var p in t.Properties)
-                yield return p;
-            if(t.BaseType!=null)
-                foreach (var p in t.BaseType.GetAllProperties())
-                    yield return p;
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var property in t.Properties)
+                    yield return property;
+            }
         }
 
-        public static IEnumerable<IXamlField> GetAllFields(this IXamlType t)
+        public static IEnumerable<IXamlField> GetAllFields(this IXamlType type)
         {
-            foreach (var p in t.Fields)
-                yield return p;
-            if (t.BaseType != null)
-                foreach (var p in t.BaseType.GetAllFields())
-                    yield return p;
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var field in t.Fields)
+                    yield return field;
+            }
         }
 
-        public static IEnumerable<IXamlEventInfo> GetAllEvents(this IXamlType t)
+        public static IEnumerable<IXamlEventInfo> GetAllEvents(this IXamlType type)
         {
-            foreach (var p in t.Events)
-                yield return p;
-            if(t.BaseType!=null)
-                foreach (var p in t.BaseType.GetAllEvents())
-                    yield return p;
+            for (var t = type; t is not null; t = t.BaseType)
+            {
+                foreach (var evt in t.Events)
+                    yield return evt;
+            }
         }
 
         public static bool IsDirectlyAssignableFrom(this IXamlType type, IXamlType other)


### PR DESCRIPTION
This PR aims to improve several hot paths clearly visible in performance snapshots (with #142 already applied):
 - Improve `Visit()` to avoid making an interface check on `ISkipXamlAstNode`.
 - Don't call `IXamlType.FullName` to check types: even if it's cached after first use, we don't need it at all, and it was basically computed for all encountered types. Comparisons can be made against `Name` + `Namespace` instead.
 - `GetMethods/GetFields/GetInterfaces/etc.` methods are no longer using recursion, avoiding the creation of quadratic iterators.
 - `TypeReferenceEqualityComparer.AreEqual()`, has fewer branches.